### PR TITLE
feat: Add domain filtering, blocklist presets, and per client DNS servers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch: # Enables manual execution from the GitHub Actions UI
 
 permissions:
   contents: write   # needed to create the Release + attach the .deb asset
@@ -26,8 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The version is the single source of truth in quota/version.py. Import it
-      # so the package metadata, the .deb filename and the Release all agree.
+      # Parses the version from code. If triggered via a Git push tag, it validates 
+      # the tag against version.py. If triggered manually, it dynamically infers the tag.
       - name: Resolve version
         id: version
         shell: bash
@@ -37,11 +38,20 @@ jobs:
           # [\"'] breaks out of the -c "..." shell quoting (the first live
           # run failed with a Python SyntaxError for exactly that reason).
           VER=$(python3 -c "import sys; sys.path.insert(0,'.'); from quota.version import __version__; print(__version__)")
-          TAG="${GITHUB_REF#refs/tags/}"
-          if [ "$TAG" != "v${VER}" ]; then
-            echo "::error::tag '$TAG' does not match quota/version.py version '$VER' (expected tag 'v$VER')"
-            exit 1
+          
+          # Check if the execution context is a Git tag push or a manual dispatch
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            if [ "$TAG" != "v${VER}" ]; then
+              echo "::error::tag '$TAG' does not match quota/version.py version '$VER' (expected tag 'v$VER')"
+              exit 1
+            fi
+          else
+            # On manual runs, dynamically generate the target tag from version.py
+            TAG="v${VER}"
+            echo "::notice::Manually triggered workflow. Using tag '$TAG' from code."
           fi
+          
           echo "version=$VER"
           echo "tag=$TAG"
           echo "version=$VER" >> "$GITHUB_OUTPUT"
@@ -96,13 +106,14 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/quota-manager_*.deb
+          tag_name: ${{ steps.version.outputs.tag }} # Explicitly pass the resolved tag for manual runs
           body: |
             Quota Manager **v${{ steps.version.outputs.version }}**.
 
             Install on the gateway laptop:
 
             ```bash
-            sudo apt install ./quota-manager_${{ steps.version.outputs.version }}_all.deb
+            sudo apt install ./quota-manager_\${{ steps.version.outputs.version }}_all.deb
             ```
 
             The package configures the network stack, installs the Python

--- a/Structure_README.md
+++ b/Structure_README.md
@@ -280,6 +280,79 @@ either way.
 
 ---
 
+## DNS filtering (domain rules, presets, per-client DNS servers)
+
+`quota/dns_rules.py` is a **third** generated-config layer, alongside
+nftables (packet accounting/blocking) and tc (speed shaping) — but it never
+touches either. It rides entirely on the DHCP+DNS server the box already
+runs (`dnsmasq`), writing two extra files into its `conf-dir`
+(`/etc/dnsmasq.d` by default):
+
+- **`quota-tags.conf`** — `dhcp-host=<mac>,set:qmdev<id>` for every known
+  device. This is the whole mechanism that makes *per-device* or *per-user*
+  rules possible: dnsmasq selects config lines by DHCP tag, so binding a MAC
+  to a tag is the "is this rule for THIS device" selector.
+- **`quota-domains.conf`** — the actual rules, as tag-restricted
+  `address=/domain/target` (block/redirect) or `server=/domain/#`
+  (allow-list override) lines, plus tag-restricted `server=<ip>` lines for
+  per-user/per-device upstream DNS servers. A user-scoped rule/override is
+  fanned out to one line per device that user currently owns (dnsmasq only
+  understands per-device tags).
+
+```
+domain_rules (DB) ──┐
+dns_presets  (DB) ──┼─► DnsRuleManager.apply() ─► write quota-tags.conf
+users.dns_server ───┤                              write quota-domains.conf
+devices.dns_server ─┘                              (only if content changed)
+                                                            │
+                                                   dnsmasq --test (validate)
+                                                            │
+                                                  systemctl restart dnsmasq
+```
+
+Both files are rewritten and diffed on every maintenance tick and
+immediately after any `/api/dns/*` (or `/api/{users,devices}/{id}/dns`)
+edit — same signature-gated pattern as the nftables blocked set and the tc
+tree: an unchanged render never touches dnsmasq. Unlike a SIGHUP (which only
+re-reads `/etc/hosts` and lease-adjacent files), new `address=`/`server=`/
+`dhcp-host=` lines need a **restart** to take effect, so a rule change costs
+every client a brief (~1 s) DNS blip — acceptable for an admin edit, not
+something that happens on its own.
+
+**Blocklist presets** (`ads-tracking`, `social-media`, `streaming`,
+`gambling`) are curated source lists — hosts-format or AdBlock-Plus-format —
+fetched and compiled down to a flat domain set by `compile_source_text`.
+Enabling one inserts `domain_rules` rows tagged
+`source='preset:<id>:<scope>:<scope_id>'`; disabling deletes exactly those
+rows. Only the network-address-shaped subset of an AdBlock-Plus list
+(`||domain^`) has a DNS-layer equivalent — element-hiding, path, and regex
+rules are dropped during compilation, which is an honest ceiling, not a bug.
+
+**Known limitation, by design of the technique**: this is DNS-layer
+filtering. A client using DNS-over-HTTPS/TLS to a resolver outside the box,
+or one that hardcodes a destination IP, bypasses it — the same way it
+already bypasses the box's regular DNS. Nothing about this feature changes
+that.
+
+**Known limitation, parallel to an existing one**: per-device/per-user rules
+and DNS-server overrides depend entirely on the DHCP tag
+(`quota-tags.conf`'s `dhcp-host=<mac>,set:qmdev<id>`), which dnsmasq only
+assigns to a MAC it has actually leased. A **static-IP device is invisible
+to tagging** the exact same way it is already invisible to the per-device
+block enforcement documented in `CLAUDE.md`'s `[LEGACY_DEBT_AND_RISKS]`
+("Per-device block can silently not cut a lease-less device") — a
+per-device/per-user domain rule or DNS-server override on a static-IP
+client silently does nothing, with no error surfaced anywhere.
+**Global-scope rules are unaffected** (no tag needed). The ARP gateway-lock
+(`engine.gateway_arp_lock`) only narrows this: it denies a static-IP device
+that points at the ROUTER as its gateway (the common bypass), but a
+static-IP device that already points at the BOX as its gateway is counted
+and blocked normally by IP yet still never gets a tag — it is not a full
+fix for the tagging gap, the same way it is not a full fix for the
+per-device block gap.
+
+---
+
 ## Rogue devices & the ARP gateway-lock
 
 Because the router keeps WiFi and shares the client segment, a device can assign
@@ -574,6 +647,15 @@ report:
   allowed_ips: []             # extra CIDRs/IPs, e.g. ["192.168.1.0/24", "10.0.0.5"].
                               #   run.py fills client_subnet from the engine's
                               #   resolved subnet automatically.
+
+dns_filter:
+  enabled: true               # domain rules / presets / per-client DNS servers.
+                              #   false => the feature is entirely inert.
+  conf_dir: /etc/dnsmasq.d    # dnsmasq's conf-dir (Debian/Kali default)
+  tags_file: quota-tags.conf     # per-device DHCP tag bindings (generated)
+  rules_file: quota-domains.conf # domain rules + DNS-server overrides (generated)
+  reload_dnsmasq: true        # restart dnsmasq when the generated files change
+  preset_cache_dir: data/dns_presets
 ```
 
 > **Speed shaping is switched on in the dashboard, not in this YAML.**
@@ -602,6 +684,12 @@ sets a session cookie. The dashboard client uses the same endpoints.
 | POST | `/api/reset-month` | force an early period roll-over |
 | GET/POST | `/api/guest` | guest mode: auto-register new devices with their own small allowance |
 | GET/POST | `/api/network` | speed-shaping settings: `enabled`, `total_down_mbps`, `total_up_mbps`, `aqm` |
+| GET/POST/PATCH/DELETE | `/api/dns/rules` | domain-filtering rules: list (optionally `?scope=&scope_id=`) / create (`{"scope","scope_id","action":"block"\|"allow"\|"redirect","domain","target_ip"}`) / enable-disable via PATCH / delete |
+| POST | `/api/dns/import` | paste raw hosts-format or AdBlock-Plus-format blocklist text (`{"text","format":"auto"\|"hosts"\|"adblock","scope","scope_id","action"}`) → bulk-creates domain rules |
+| GET | `/api/dns/presets` | list built-in blocklist presets (ads-tracking, social-media, streaming, gambling) with their enabled state + domain count |
+| POST | `/api/dns/presets/{id}/enable` · `/disable` | fetch + compile a preset's sources into domain rules for a scope (`{"scope","scope_id"}`), or remove exactly those rules |
+| POST | `/api/dns/apply` | force an immediate dnsmasq regeneration + reload (normally automatic after every DNS-related edit) |
+| PATCH | `/api/users/{id}/dns` · `/api/devices/{id}/dns` | set/clear a per-user or per-device upstream DNS-server override (`{"dns_server": "1.1.1.1"}`, `""` clears it) |
 | GET/POST | `/api/wan` | strong-mode topology: `GET` live status (topology/source/pending/ppp0), `POST {"topology": "lan"\|"wan", "pppoe_user", "pppoe_password", "wan_if"}` APPLIES the topology live — rewrites config.yaml + the DB together, runs `scripts/topology.sh` (NIC + dnsmasq + PPPoE dial) and schedules a restart (`restart_scheduled`, `script_output`). Creds travel to the applier via the environment, never argv. On an applier failure config.yaml + the DB are ROLLED BACK to the previous state (no restart) |
 | POST | `/api/wan/test` | test the PPPoE credentials WITHOUT changing anything: dials a throwaway `ppp200` link via `scripts/test_pppoe.sh` with `{"pppoe_user", "pppoe_password", "wan_if"}` and reports `status` (success/auth-failed/no-pppoe-server/link-down/error), the negotiated local/peer IPs, `internet` (ping check), and `detail` — never touches config.yaml, the DB, `ppp0`, routing or DNS |
 | GET | `/api/milestone` | **public** — the requesting device's user's consumption + per-device breakdown (resolved by source IP via its DHCP lease; `recognized: false` for a lease-less IP). Pairs with the `/milestone` page |
@@ -655,6 +743,9 @@ QuotaManager/
 │   │                         #   + ARP gateway-lock deny rules (known_ips set)
 │   ├── shaping.py            # TcShaper (Linux): per-device + per-user speed caps,
 │   │                         #   low-latency fq_codel queues (HTB), two-tree design
+│   ├── dns_rules.py          # DnsRuleManager: domain blacklist/allow/redirect rules,
+│   │                         #   blocklist presets, per-client DNS-server overrides —
+│   │                         #   generated dnsmasq config, no new service
 │   ├── arp_scan.py           # rogue static-IP detection: raw-socket ARP probe of
 │   │                         #   both LAN subnets -> hosts not leased by DHCP
 │   ├── arp_lock.py           # ARP gateway-lock responder: claims the router's IP

--- a/api/app.py
+++ b/api/app.py
@@ -25,12 +25,15 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from contextlib import asynccontextmanager
 
-from api.schemas import (BundleUpdate, DeviceCreate, DeviceUpdate, GuestUpdate,
+from api.schemas import (BundleUpdate, DeviceCreate, DeviceUpdate,
+                         DnsImportRequest, DnsPresetEnable, DnsServerUpdate,
+                         DomainRuleCreate, DomainRuleUpdate, GuestUpdate,
                          LoginRequest, MilestoneNotify, NetworkUpdate,
                          PasswordUpdate, SetupComplete, TopUpRequest,
                          UserCreate, UserUpdate, WanTest, WanUpdate)
 from core import timeutil
 from quota import db as _db
+from quota import dns_rules as _dns_rules
 from quota.engine import GATEWAY_MAC, EngineSnapshot, SnapshotHolder
 from quota.service import GB, QuotaService
 from quota.vendor import vendor_for
@@ -105,6 +108,7 @@ def create_app(
     topology_manager: object | None = None,
     shaping_sync: Optional[Callable[[], object]] = None,
     report_config: object | None = None,
+    dns_apply: Optional[Callable[[], object]] = None,
 ) -> FastAPI:
     app = FastAPI(title="Quota Manager", version=__version__,
                   docs_url="/api/docs", openapi_url="/api/openapi.json")
@@ -121,6 +125,18 @@ def create_app(
             return
         try:
             asyncio.create_task(shaping_sync())
+        except RuntimeError:  # no running event loop (should not happen in a route)
+            pass
+
+    def _schedule_dns_apply() -> None:
+        """Apply a domain-rule / DNS-server edit to dnsmasq right away (no
+        15 s tick wait). Fire-and-forget, same pattern as
+        ``_schedule_shaping_sync``; ``dns_apply`` is run.py's callback and is
+        a no-op when unset (tests / degraded boot)."""
+        if dns_apply is None:
+            return
+        try:
+            asyncio.create_task(dns_apply())
         except RuntimeError:  # no running event loop (should not happen in a route)
             pass
 
@@ -757,6 +773,196 @@ def create_app(
         if result is None:
             raise HTTPException(404, "user not found")
         return result
+
+    @app.patch("/api/users/{user_id}/dns", dependencies=[Depends(_require_auth)])
+    async def set_user_dns(user_id: int, body: DnsServerUpdate) -> dict[str, Any]:
+        user = await database.get_user(user_id)
+        if user is None:
+            raise HTTPException(404, "user not found")
+        await database.update_user(user_id, dns_server=body.dns_server.strip())
+        await database.add_event(
+            f"DNS server for user '{user.name or user_id}' set to "
+            f"{body.dns_server.strip() or '(inherit default)'}", "info",
+            user_id=user_id)
+        _schedule_dns_apply()
+        return {"id": user_id, "dns_server": body.dns_server.strip()}
+
+    @app.patch("/api/devices/{device_id}/dns", dependencies=[Depends(_require_auth)])
+    async def set_device_dns(device_id: int, body: DnsServerUpdate) -> dict[str, Any]:
+        dev = await database.get_device(device_id)
+        if dev is None:
+            raise HTTPException(404, "device not found")
+        await database.update_device(device_id, dns_server=body.dns_server.strip())
+        await database.add_event(
+            f"DNS server for device '{dev.name or dev.mac}' set to "
+            f"{body.dns_server.strip() or '(inherit default)'}", "info",
+            device_id)
+        _schedule_dns_apply()
+        return {"id": device_id, "dns_server": body.dns_server.strip()}
+
+    # -- domain filtering (blacklist / allow-list / custom hosts) -----------
+
+    def _rule_view(rule: _db.DomainRule) -> dict[str, Any]:
+        return {
+            "id": rule.id, "scope": rule.scope, "scope_id": rule.scope_id,
+            "action": rule.action, "domain": rule.domain,
+            "target_ip": rule.target_ip, "enabled": rule.enabled,
+            "source": rule.source, "created_at": rule.created_at,
+        }
+
+    @app.get("/api/dns/rules", dependencies=[Depends(_require_auth)])
+    async def list_dns_rules(scope: Optional[str] = None,
+                             scope_id: Optional[int] = None) -> list[dict[str, Any]]:
+        rules = await database.list_domain_rules(scope, scope_id)
+        return [_rule_view(r) for r in rules]
+
+    @app.post("/api/dns/rules", status_code=201, dependencies=[Depends(_require_auth)])
+    async def create_dns_rule(body: DomainRuleCreate) -> dict[str, Any]:
+        if body.scope != "global" and body.scope_id is None:
+            raise HTTPException(400, "scope_id is required for a user/device rule")
+        if body.action == "redirect" and not body.target_ip:
+            raise HTTPException(400, "target_ip is required for a redirect rule")
+        try:
+            domain = _dns_rules.normalize_pattern(body.domain)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from None
+        if body.scope == "user" and await database.get_user(body.scope_id) is None:
+            raise HTTPException(404, "user not found")
+        if body.scope == "device" and await database.get_device(body.scope_id) is None:
+            raise HTTPException(404, "device not found")
+        rule = await database.create_domain_rule(
+            body.scope, body.action, domain, scope_id=body.scope_id,
+            target_ip=body.target_ip, enabled=body.enabled, source="manual")
+        await database.add_event(
+            f"DNS rule added: {body.action} {domain} ({body.scope})", "info")
+        _schedule_dns_apply()
+        return _rule_view(rule)
+
+    @app.patch("/api/dns/rules/{rule_id}", dependencies=[Depends(_require_auth)])
+    async def update_dns_rule(rule_id: int, body: DomainRuleUpdate) -> dict[str, Any]:
+        rule = await database.get_domain_rule(rule_id)
+        if rule is None:
+            raise HTTPException(404, "rule not found")
+        fields: dict[str, Any] = {}
+        if body.enabled is not None:
+            fields["enabled"] = body.enabled
+        if body.target_ip is not None:
+            fields["target_ip"] = body.target_ip
+        if fields:
+            await database.update_domain_rule(rule_id, **fields)
+        _schedule_dns_apply()
+        return {"id": rule_id, "updated": True}
+
+    @app.delete("/api/dns/rules/{rule_id}", dependencies=[Depends(_require_auth)])
+    async def delete_dns_rule(rule_id: int) -> dict[str, Any]:
+        rule = await database.get_domain_rule(rule_id)
+        if rule is None:
+            raise HTTPException(404, "rule not found")
+        await database.delete_domain_rule(rule_id)
+        await database.add_event(f"DNS rule removed: {rule.action} {rule.domain}", "info")
+        _schedule_dns_apply()
+        return {"id": rule_id, "deleted": True}
+
+    @app.post("/api/dns/import", dependencies=[Depends(_require_auth)])
+    async def import_dns_rules(body: DnsImportRequest) -> dict[str, Any]:
+        """Paste raw hosts-format or AdBlock-Plus-format text -> domain_rules
+        rows. Individual malformed domains are skipped, not fatal — a large
+        pasted list commonly has a handful of stray lines."""
+        if body.scope != "global" and body.scope_id is None:
+            raise HTTPException(400, "scope_id is required for a user/device rule")
+        domains = _dns_rules.compile_source_text(body.text, body.format)
+        created, skipped = 0, 0
+        for raw_domain in domains:
+            try:
+                domain = _dns_rules.normalize_pattern(raw_domain)
+            except ValueError:
+                skipped += 1
+                continue
+            await database.create_domain_rule(
+                body.scope, body.action, domain, scope_id=body.scope_id,
+                source="import")
+            created += 1
+        await database.add_event(
+            f"Imported {created} domain rule(s) ({body.action}, {skipped} skipped)",
+            "info")
+        _schedule_dns_apply()
+        return {"created": created, "skipped": skipped}
+
+    @app.get("/api/dns/presets", dependencies=[Depends(_require_auth)])
+    async def list_dns_presets() -> list[dict[str, Any]]:
+        states = {s["preset_id"]: s for s in await database.list_preset_states()}
+        out = []
+        for preset in _dns_rules.PRESETS.values():
+            state = states.get(preset.id, {})
+            out.append({
+                "id": preset.id, "name": preset.name,
+                "description": preset.description,
+                "enabled": bool(state.get("enabled", 0)),
+                "scope": state.get("scope", "global"),
+                "scope_id": state.get("scope_id"),
+                "domain_count": state.get("domain_count", 0),
+                "updated_at": state.get("updated_at", 0),
+            })
+        return out
+
+    @app.post("/api/dns/presets/{preset_id}/enable", dependencies=[Depends(_require_auth)])
+    async def enable_dns_preset(preset_id: str, body: DnsPresetEnable) -> dict[str, Any]:
+        preset = _dns_rules.PRESETS.get(preset_id)
+        if preset is None:
+            raise HTTPException(404, "unknown preset")
+        if body.scope != "global" and body.scope_id is None:
+            raise HTTPException(400, "scope_id is required for a user/device preset")
+        # Fetching runs in a thread — it's a blocking network call (urllib)
+        # and must never stall the event loop / WebSocket push.
+        try:
+            domains = await asyncio.to_thread(_dns_rules.fetch_preset, preset)
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(502, f"failed to fetch preset sources: {exc}") from None
+        source_tag = f"preset:{preset_id}:{body.scope}:{body.scope_id or 0}"
+        # Replace any previous rules from this exact preset+scope (a refresh
+        # re-enables cleanly instead of accumulating stale domains forever).
+        await database.delete_domain_rules_by_source(source_tag)
+        count = 0
+        for raw_domain in domains:
+            try:
+                domain = _dns_rules.normalize_pattern(raw_domain)
+            except ValueError:
+                continue
+            await database.create_domain_rule(
+                body.scope, "block", domain, scope_id=body.scope_id,
+                source=source_tag)
+            count += 1
+        await database.set_preset_state(
+            preset_id, True, scope=body.scope, scope_id=body.scope_id,
+            domain_count=count)
+        await database.add_event(
+            f"DNS preset enabled: {preset.name} ({count} domains, {body.scope})",
+            "info")
+        _schedule_dns_apply()
+        return {"id": preset_id, "enabled": True, "domain_count": count}
+
+    @app.post("/api/dns/presets/{preset_id}/disable", dependencies=[Depends(_require_auth)])
+    async def disable_dns_preset(preset_id: str, body: DnsPresetEnable) -> dict[str, Any]:
+        if preset_id not in _dns_rules.PRESETS:
+            raise HTTPException(404, "unknown preset")
+        source_tag = f"preset:{preset_id}:{body.scope}:{body.scope_id or 0}"
+        removed = await database.delete_domain_rules_by_source(source_tag)
+        await database.set_preset_state(
+            preset_id, False, scope=body.scope, scope_id=body.scope_id,
+            domain_count=0)
+        await database.add_event(
+            f"DNS preset disabled: {preset_id} ({removed} rules removed)", "info")
+        _schedule_dns_apply()
+        return {"id": preset_id, "enabled": False, "removed": removed}
+
+    @app.post("/api/dns/apply", dependencies=[Depends(_require_auth)])
+    async def apply_dns_now() -> dict[str, Any]:
+        """Force an immediate dnsmasq regeneration + reload (normally
+        automatic after every rule/preset/DNS-server edit above)."""
+        if dns_apply is None:
+            return {"applied": False, "reason": "dns manager not wired"}
+        await dns_apply()
+        return {"applied": True}
 
     @app.get("/api/usage/{device_id}", dependencies=[Depends(_require_auth)])
     async def usage_series(device_id: int, since: str = "") -> list[dict[str, Any]]:

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import ipaddress
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 def _cap_field() -> Field:
@@ -151,6 +152,106 @@ class WanUpdate(BaseModel):
     pppoe_user: Optional[str] = None
     pppoe_password: Optional[str] = None
     wan_if: Optional[str] = None
+
+
+class DnsServerUpdate(BaseModel):
+    """Per-user or per-device upstream DNS-server override.
+
+    Rendered as a tag-restricted dnsmasq ``server=`` line (see
+    quota/dns_rules.py). Empty string clears the override (falls back to the
+    user's override, then the gateway's default upstreams). Must be a bare
+    IPv4/IPv6 address — this string is written directly into generated
+    dnsmasq config, so anything else (in particular embedded whitespace/
+    newlines) is rejected rather than risk a config-injection line.
+    """
+
+    dns_server: str = Field("", max_length=64)
+
+    @field_validator("dns_server")
+    @classmethod
+    def _validate_ip_or_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            return v
+        try:
+            ipaddress.ip_address(v)
+        except ValueError:
+            raise ValueError(
+                f"dns_server must be a bare IP address, got {v!r}") from None
+        return v
+
+
+class DomainRuleCreate(BaseModel):
+    """One domain-filtering rule. ``scope``/``scope_id`` together decide who
+    it applies to: ``global`` (scope_id ignored), ``user`` (scope_id = a
+    user id — fanned out to every device that user owns), or ``device``
+    (scope_id = a device id). ``domain`` accepts an optional leading
+    ``*.`` (stripped — dnsmasq's match already includes every subdomain);
+    any other ``*`` is rejected as unenforceable. ``target_ip`` is only used
+    when ``action == "redirect"`` and must be a bare IP — like
+    ``dns_server``, it is written directly into generated dnsmasq config.
+    """
+
+    scope: str = Field("global", pattern="^(global|user|device)$")
+    scope_id: Optional[int] = None
+    action: str = Field("block", pattern="^(block|allow|redirect)$")
+    domain: str = Field(..., min_length=1, max_length=253)
+    target_ip: Optional[str] = None
+    enabled: bool = True
+
+    @field_validator("target_ip")
+    @classmethod
+    def _validate_target_ip(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or not v.strip():
+            return None
+        v = v.strip()
+        try:
+            ipaddress.ip_address(v)
+        except ValueError:
+            raise ValueError(
+                f"target_ip must be a bare IP address, got {v!r}") from None
+        return v
+
+
+class DomainRuleUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    target_ip: Optional[str] = None
+
+    @field_validator("target_ip")
+    @classmethod
+    def _validate_target_ip(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or not v.strip():
+            return v  # None = "leave unchanged" for a PATCH; see api/app.py
+        v = v.strip()
+        try:
+            ipaddress.ip_address(v)
+        except ValueError:
+            raise ValueError(
+                f"target_ip must be a bare IP address, got {v!r}") from None
+        return v
+
+
+class DnsPresetEnable(BaseModel):
+    """Turn a built-in blocklist preset on/off for a scope (default: the
+    whole household). Enabling fetches + compiles the preset's source(s)
+    (or uses the curated inline list for presets with none) into
+    ``domain_rules`` rows tagged ``source='preset:<preset_id>'``; disabling
+    removes exactly those rows."""
+
+    scope: str = Field("global", pattern="^(global|user|device)$")
+    scope_id: Optional[int] = None
+
+
+class DnsImportRequest(BaseModel):
+    """Paste raw hosts-format or AdBlock-Plus-format blocklist text and turn
+    it into domain_rules rows (source='import'). ``format`` picks the
+    parser; "auto" tries hosts-format first, then AdBlock-Plus."""
+
+    text: str = Field(..., min_length=1)
+    format: str = Field("auto", pattern="^(auto|hosts|adblock)$")
+    scope: str = Field("global", pattern="^(global|user|device)$")
+    scope_id: Optional[int] = None
+    action: str = Field("block", pattern="^(block|allow)$")
 
 
 class WanTest(BaseModel):

--- a/config.yaml
+++ b/config.yaml
@@ -121,3 +121,28 @@ report:
   enabled: true
   allow_client_subnet: true
   allowed_ips: []
+
+# Domain-level DNS filtering: per-user/per-device blacklists, allow-list
+# exceptions, custom host redirects, curated blocklist presets (ads/tracking,
+# social media, streaming, gambling), and per-user/per-device upstream
+# DNS-server overrides. Implemented as GENERATED dnsmasq config — no new
+# service is started, and this box already owns DHCP+DNS (see the dhcp:
+# block above). Rules/presets/DNS-server overrides themselves are edited in
+# the dashboard (stored in the DB, api/app.py's /api/dns/* routes); this
+# block only sets where the generated files live and whether to auto-reload.
+#   enabled: true              # master switch
+#   conf_dir: /etc/dnsmasq.d   # dnsmasq's conf-dir (Debian/Kali default)
+#   tags_file: quota-tags.conf     # per-device DHCP tag bindings
+#   rules_file: quota-domains.conf # domain rules + DNS-server overrides
+#   reload_dnsmasq: true       # restart dnsmasq when the generated files
+#                              # change (new address=/server= lines are only
+#                              # picked up on a restart, not a SIGHUP — costs
+#                              # clients a ~1s DNS blip per rule change)
+#   preset_cache_dir: data/dns_presets
+dns_filter:
+  enabled: true
+  conf_dir: /etc/dnsmasq.d
+  tags_file: quota-tags.conf
+  rules_file: quota-domains.conf
+  reload_dnsmasq: true
+  preset_cache_dir: data/dns_presets

--- a/core/config.py
+++ b/core/config.py
@@ -167,6 +167,44 @@ class ReportConfig:
 
 
 @dataclass
+class DnsFilterConfig:
+    """Domain-level filtering: per-user/per-device blacklists, allow-list
+    exceptions, custom host redirects, curated blocklist presets, and
+    per-user/per-device upstream DNS-server overrides.
+
+    Implemented entirely as GENERATED dnsmasq configuration — this box
+    already owns DHCP + DNS (see ``DhcpConfig``), so no new service is
+    started and the nftables/tc packet paths are untouched. See
+    ``quota/dns_rules.py`` for the renderer/parsers and
+    ``quota.db``'s ``domain_rules`` / ``dns_presets`` tables for storage.
+    """
+
+    enabled: bool = True
+    #: Directory dnsmasq scans for ``*.conf`` (Debian/Kali ship
+    #: ``conf-dir=/etc/dnsmasq.d`` in ``/etc/dnsmasq.conf`` by default — the
+    #: setup script does not need to add this on a stock install).
+    conf_dir: str = "/etc/dnsmasq.d"
+    #: Filenames written INSIDE conf_dir. Kept separate from
+    #: ``quota-gateway.conf`` (the DHCP/DNS base config written by the setup
+    #: script) so a domain-rule edit never touches the base file, and kept
+    #: separate from EACH OTHER so tags (rarely change) and rules (change
+    #: often) can be diffed/rewritten independently.
+    tags_file: str = "quota-tags.conf"
+    rules_file: str = "quota-domains.conf"
+    #: dnsmasq only picks up NEW ``address=``/``server=``/``dhcp-host=``
+    #: lines on a restart — SIGHUP only re-reads ``/etc/hosts`` and
+    #: lease-adjacent files. True (default) restarts dnsmasq whenever the
+    #: generated files actually changed (~1 s DNS blip for clients); False
+    #: writes the files but skips the reload, for an admin who wants to
+    #: batch several edits before a manual ``systemctl restart dnsmasq``.
+    reload_dnsmasq: bool = True
+    #: Where fetched blocklist presets are cached on disk (raw text, so a
+    #: restart does not need to re-fetch before an already-enabled preset's
+    #: rules can be rebuilt). Relative paths resolve under the project root.
+    preset_cache_dir: str = "data/dns_presets"
+
+
+@dataclass
 class Config:
     db_path: str = "data/quota.db"
     log_file: str = "logs/quota.log"
@@ -177,6 +215,7 @@ class Config:
     web: WebConfig = field(default_factory=WebConfig)
     shaping: ShapingConfig = field(default_factory=ShapingConfig)
     report: ReportConfig = field(default_factory=ReportConfig)
+    dns_filter: DnsFilterConfig = field(default_factory=DnsFilterConfig)
     timezone: str = ""  # empty => system local timezone
 
 

--- a/quota/db.py
+++ b/quota/db.py
@@ -43,6 +43,17 @@ BLOCK_OK = "ok"          # allowed, within quota
 BLOCK_QUOTA = "quota"    # exceeded monthly allowance
 BLOCK_ADMIN = "admin_off"  # manually switched off by admin
 
+# Domain-rule scope + action enums (see quota/dns_rules.py for the same
+# constants used by the dnsmasq renderer — kept independent so db.py never
+# has to import the renderer module).
+DNS_SCOPE_GLOBAL = "global"
+DNS_SCOPE_USER = "user"
+DNS_SCOPE_DEVICE = "device"
+
+DNS_ACTION_BLOCK = "block"
+DNS_ACTION_ALLOW = "allow"
+DNS_ACTION_REDIRECT = "redirect"
+
 
 # ---------------------------------------------------------------------------
 # Row models
@@ -70,6 +81,11 @@ class Device:
     #: tc shaper (quota/shaping.py).
     limit_down_mbps: float = 0.0
     limit_up_mbps: float = 0.0
+    #: Per-device upstream DNS server override (empty = inherit the user's
+    #: override, or the gateway's default upstreams if neither is set).
+    #: Rendered as a tag-restricted dnsmasq `server=` line — see
+    #: quota/dns_rules.py.
+    dns_server: str = ""
 
     @property
     def is_blocked(self) -> bool:
@@ -106,10 +122,33 @@ class User:
     notified_50: bool = False
     notified_75: bool = False
     notified_100: bool = False
+    #: Per-user upstream DNS server override, inherited by every device of
+    #: this user that has no override of its own (empty = no override).
+    dns_server: str = ""
 
     @property
     def is_admin_blocked(self) -> bool:
         return self.block_state == BLOCK_ADMIN
+
+
+@dataclass
+class DomainRule:
+    """One domain-filtering rule: block/allow/redirect a domain (+ every
+    subdomain — dnsmasq's match already covers those), scoped globally, to a
+    user (fanned out to all their devices at render time), or to a single
+    device. See quota/dns_rules.py for how this becomes dnsmasq config."""
+
+    id: int
+    scope: str = DNS_SCOPE_GLOBAL          # 'global' | 'user' | 'device'
+    scope_id: Optional[int] = None         # user_id / device_id; None for global
+    action: str = DNS_ACTION_BLOCK         # 'block' | 'allow' | 'redirect'
+    domain: str = ""                       # normalized, no leading "*."
+    target_ip: Optional[str] = None        # only meaningful for 'redirect'
+    enabled: bool = True
+    #: 'manual' (admin-entered) | 'preset:<preset_id>' (from an enabled
+    #: blocklist preset) | 'import' (pasted hosts/AdBlock-Plus text).
+    source: str = "manual"
+    created_at: float = 0.0
 
 
 @dataclass
@@ -141,7 +180,8 @@ CREATE TABLE IF NOT EXISTS devices (
     created_at       REAL NOT NULL,
     topup_gb         REAL NOT NULL DEFAULT 0,
     limit_down_mbps  REAL NOT NULL DEFAULT 0,
-    limit_up_mbps    REAL NOT NULL DEFAULT 0
+    limit_up_mbps    REAL NOT NULL DEFAULT 0,
+    dns_server       TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS leases (
@@ -196,12 +236,45 @@ CREATE TABLE IF NOT EXISTS users (
     limit_up_mbps    REAL NOT NULL DEFAULT 0,
     notified_50      INTEGER NOT NULL DEFAULT 0,
     notified_75      INTEGER NOT NULL DEFAULT 0,
-    notified_100     INTEGER NOT NULL DEFAULT 0
+    notified_100     INTEGER NOT NULL DEFAULT 0,
+    dns_server       TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS suppressed_macs (
     mac        TEXT PRIMARY KEY,
     created_at REAL NOT NULL
+);
+
+-- Domain-level DNS filtering (quota/dns_rules.py renders these into
+-- generated dnsmasq config). scope_id is a user_id or device_id depending on
+-- `scope`, and NULL for scope='global'. The UNIQUE constraint makes
+-- (re-)enabling the same domain/action at the same scope idempotent.
+CREATE TABLE IF NOT EXISTS domain_rules (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    scope      TEXT NOT NULL DEFAULT 'global',
+    scope_id   INTEGER,
+    action     TEXT NOT NULL DEFAULT 'block',
+    domain     TEXT NOT NULL,
+    target_ip  TEXT,
+    enabled    INTEGER NOT NULL DEFAULT 1,
+    source     TEXT NOT NULL DEFAULT 'manual',
+    created_at REAL NOT NULL,
+    UNIQUE(scope, scope_id, domain, action)
+);
+
+-- One row per built-in blocklist preset (quota/dns_rules.py:PRESETS) that
+-- has ever been enabled somewhere, so the dashboard can show its state
+-- (enabled/disabled, how many domains, when it was last refreshed) without
+-- re-fetching the source. Enabling a preset also inserts domain_rules rows
+-- (source='preset:<preset_id>') for its compiled domain list; disabling it
+-- deletes those rows again.
+CREATE TABLE IF NOT EXISTS dns_presets (
+    preset_id    TEXT PRIMARY KEY,
+    enabled      INTEGER NOT NULL DEFAULT 0,
+    scope        TEXT NOT NULL DEFAULT 'global',
+    scope_id     INTEGER,
+    domain_count INTEGER NOT NULL DEFAULT 0,
+    updated_at   REAL NOT NULL DEFAULT 0
 );
 """
 
@@ -292,6 +365,18 @@ class Database:
                 await self._conn.execute(
                     f"ALTER TABLE users ADD COLUMN {col} "
                     "INTEGER NOT NULL DEFAULT 0")
+                await self._conn.commit()
+            except Exception:  # noqa: BLE001  (duplicate column on existing DBs)
+                pass
+        # v22 DNS filtering: per-user/per-device upstream DNS-server override
+        # column (domain_rules / dns_presets are brand-new tables, created by
+        # the executescript above — no ALTER needed for those). ALTER no-ops
+        # when already present (fresh SCHEMA includes it).
+        for table in ("devices", "users"):
+            try:
+                await self._conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN dns_server "
+                    "TEXT NOT NULL DEFAULT ''")
                 await self._conn.commit()
             except Exception:  # noqa: BLE001  (duplicate column on existing DBs)
                 pass
@@ -412,7 +497,8 @@ class Database:
 
     async def update_device(self, device_id: int, **fields: Any) -> Device | None:
         allowed = {"name", "quota_mode", "fixed_gb", "block_state",
-                   "user_id", "bypass", "limit_down_mbps", "limit_up_mbps"}
+                   "user_id", "bypass", "limit_down_mbps", "limit_up_mbps",
+                   "dns_server"}
         sets, args = [], []
         for key, value in fields.items():
             if key in allowed:
@@ -443,6 +529,9 @@ class Database:
                     await self.add_suppressed_mac(row["mac"])
         await self.conn.execute("DELETE FROM devices WHERE id=?", (device_id,))
         await self.conn.commit()
+        # Device-scoped domain rules are meaningless once the device is gone
+        # (their dnsmasq tag would never be applied to anything again).
+        await self.delete_domain_rules_by_scope(DNS_SCOPE_DEVICE, device_id)
 
     async def set_device_state(self, device_id: int, state: str) -> None:
         await self.update_device(device_id, block_state=state)
@@ -520,7 +609,7 @@ class Database:
     async def update_user(self, user_id: int, **fields: Any) -> User | None:
         allowed = {"name", "quota_mode", "fixed_gb", "block_state",
                    "limit_down_mbps", "limit_up_mbps",
-                   "notified_50", "notified_75", "notified_100"}
+                   "notified_50", "notified_75", "notified_100", "dns_server"}
         sets, args = [], []
         for key, value in fields.items():
             if key in allowed:
@@ -554,8 +643,10 @@ class Database:
             await self.conn.execute(
                 "DELETE FROM usage_daily WHERE device_id=?", (r["id"],))
             await self.conn.execute("DELETE FROM devices WHERE id=?", (r["id"],))
+            await self.delete_domain_rules_by_scope(DNS_SCOPE_DEVICE, r["id"])
         await self.conn.execute("DELETE FROM users WHERE id=?", (user_id,))
         await self.conn.commit()
+        await self.delete_domain_rules_by_scope(DNS_SCOPE_USER, user_id)
         return len(rows)
 
     async def add_topup_user(self, user_id: int, extra_gb: float) -> None:
@@ -835,6 +926,145 @@ class Database:
             "SELECT * FROM events ORDER BY ts DESC LIMIT ?", (limit,))
         return [dict(r) for r in rows]
 
+    # -- domain rules (DNS filtering) ----------------------------------------
+
+    async def create_domain_rule(self, scope: str, action: str, domain: str,
+                                 scope_id: int | None = None,
+                                 target_ip: str | None = None,
+                                 enabled: bool = True,
+                                 source: str = "manual") -> DomainRule:
+        """Insert (or update, if the same scope/scope_id/domain/action
+        combination already exists — the UNIQUE constraint makes this an
+        upsert) one domain rule."""
+        now = time.time()
+        await self.conn.execute(
+            """INSERT INTO domain_rules
+                 (scope, scope_id, action, domain, target_ip, enabled, source, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(scope, scope_id, domain, action) DO UPDATE SET
+                 target_ip=excluded.target_ip, enabled=excluded.enabled,
+                 source=excluded.source""",
+            (scope, scope_id, action, domain, target_ip, int(enabled),
+             source, now))
+        await self.conn.commit()
+        row = await self._fetch_one(
+            "SELECT * FROM domain_rules WHERE scope=? AND scope_id IS ? "
+            "AND domain=? AND action=?", (scope, scope_id, domain, action))
+        return _row_to_domain_rule(row)  # type: ignore[arg-type]
+
+    async def get_domain_rule(self, rule_id: int) -> DomainRule | None:
+        row = await self._fetch_one(
+            "SELECT * FROM domain_rules WHERE id=?", (rule_id,))
+        return _row_to_domain_rule(row) if row else None
+
+    async def list_domain_rules(self, scope: str | None = None,
+                                scope_id: int | None = None,
+                                enabled_only: bool = False) -> list[DomainRule]:
+        """List rules, optionally filtered to one scope (and scope_id).
+        With no filter, returns every rule at every scope — what the
+        renderer (quota/dns_rules.py) needs to build the full config."""
+        sql = "SELECT * FROM domain_rules WHERE 1=1"
+        args: list[Any] = []
+        if scope is not None:
+            sql += " AND scope=?"
+            args.append(scope)
+            if scope_id is not None:
+                sql += " AND scope_id=?"
+                args.append(scope_id)
+        if enabled_only:
+            sql += " AND enabled=1"
+        sql += " ORDER BY id"
+        rows = await self.conn.execute_fetchall(sql, args)
+        return [_row_to_domain_rule(r) for r in rows]
+
+    async def update_domain_rule(self, rule_id: int, **fields: Any) -> DomainRule | None:
+        allowed = {"enabled", "target_ip", "domain", "action"}
+        sets, args = [], []
+        for key, value in fields.items():
+            if key in allowed:
+                sets.append(f"{key}=?")
+                args.append(int(value) if key == "enabled" else value)
+        if not sets:
+            return await self.get_domain_rule(rule_id)
+        args.append(rule_id)
+        await self.conn.execute(
+            f"UPDATE domain_rules SET {', '.join(sets)} WHERE id=?", args)
+        await self.conn.commit()
+        return await self.get_domain_rule(rule_id)
+
+    async def delete_domain_rule(self, rule_id: int) -> None:
+        await self.conn.execute("DELETE FROM domain_rules WHERE id=?", (rule_id,))
+        await self.conn.commit()
+
+    async def delete_domain_rules_by_source(self, source: str) -> int:
+        """Delete every rule with an exact ``source`` match (used to remove
+        a disabled preset's generated rules in one shot). Returns the count
+        removed."""
+        rows = await self.conn.execute_fetchall(
+            "SELECT id FROM domain_rules WHERE source=?", (source,))
+        await self.conn.execute(
+            "DELETE FROM domain_rules WHERE source=?", (source,))
+        await self.conn.commit()
+        return len(rows)
+
+    async def delete_domain_rules_by_scope(self, scope: str, scope_id: int | None) -> int:
+        """Delete every rule at one scope (used when a user/device is
+        deleted, so their per-scope rules don't linger orphaned)."""
+        rows = await self.conn.execute_fetchall(
+            "SELECT id FROM domain_rules WHERE scope=? AND scope_id IS ?",
+            (scope, scope_id))
+        await self.conn.execute(
+            "DELETE FROM domain_rules WHERE scope=? AND scope_id IS ?",
+            (scope, scope_id))
+        await self.conn.commit()
+        return len(rows)
+
+    # -- DNS blocklist presets ------------------------------------------------
+
+    async def get_preset_state(self, preset_id: str) -> dict[str, Any] | None:
+        row = await self._fetch_one(
+            "SELECT * FROM dns_presets WHERE preset_id=?", (preset_id,))
+        return dict(row) if row else None
+
+    async def list_preset_states(self) -> list[dict[str, Any]]:
+        rows = await self.conn.execute_fetchall(
+            "SELECT * FROM dns_presets ORDER BY preset_id")
+        return [dict(r) for r in rows]
+
+    async def set_preset_state(self, preset_id: str, enabled: bool,
+                               scope: str = DNS_SCOPE_GLOBAL,
+                               scope_id: int | None = None,
+                               domain_count: int = 0) -> None:
+        await self.conn.execute(
+            """INSERT INTO dns_presets (preset_id, enabled, scope, scope_id,
+                 domain_count, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)
+               ON CONFLICT(preset_id) DO UPDATE SET
+                 enabled=excluded.enabled, scope=excluded.scope,
+                 scope_id=excluded.scope_id, domain_count=excluded.domain_count,
+                 updated_at=excluded.updated_at""",
+            (preset_id, int(enabled), scope, scope_id, domain_count, time.time()))
+        await self.conn.commit()
+
+    async def delete_preset_state(self, preset_id: str) -> None:
+        await self.conn.execute(
+            "DELETE FROM dns_presets WHERE preset_id=?", (preset_id,))
+        await self.conn.commit()
+
+
+def _row_to_domain_rule(row: Any) -> DomainRule:
+    return DomainRule(
+        id=row["id"],
+        scope=row["scope"],
+        scope_id=row["scope_id"],
+        action=row["action"],
+        domain=row["domain"],
+        target_ip=row["target_ip"],
+        enabled=bool(row["enabled"]),
+        source=row["source"],
+        created_at=row["created_at"],
+    )
+
 
 def _row_to_device(row: Any) -> Device:
     return Device(
@@ -850,6 +1080,7 @@ def _row_to_device(row: Any) -> Device:
         bypass=bool(row["bypass"]),
         limit_down_mbps=float(row["limit_down_mbps"] or 0.0),
         limit_up_mbps=float(row["limit_up_mbps"] or 0.0),
+        dns_server=row["dns_server"] or "",
     )
 
 
@@ -869,4 +1100,5 @@ def _row_to_user(row: Any) -> User:
         notified_50=bool(row["notified_50"]),
         notified_75=bool(row["notified_75"]),
         notified_100=bool(row["notified_100"]),
+        dns_server=row["dns_server"] or "",
     )

--- a/quota/dns_rules.py
+++ b/quota/dns_rules.py
@@ -1,0 +1,474 @@
+"""Domain-level DNS filtering: blacklists, allow-list exceptions, custom host
+redirects, curated blocklist presets, and per-user/per-device upstream
+DNS-server overrides.
+
+Why this rides on dnsmasq instead of adding a new component
+-------------------------------------------------------------
+dnsmasq already owns DHCP + DNS on the gateway (see ``quota/db.py``'s module
+docstring and ``scripts/setup_gateway_kali.sh``). It already natively
+supports everything this feature needs:
+
+- ``address=/domain/target`` blackholes or redirects a domain AND every
+  subdomain of it — that IS the "wildcard" behaviour most people mean by
+  domain blocking; dnsmasq has no syntax for a glob in the MIDDLE of a
+  label, so a pattern like ``*.ads.*.example.com`` cannot be expressed here
+  (see :func:`normalize_pattern`, which rejects it rather than silently
+  accepting something that would never actually block anything).
+- ``server=upstream$tag`` sends one client's queries to a specific resolver
+  — the per-client DNS-server feature, for free.
+- DHCP tags (``dhcp-host=mac,set:tag``) are already how the box could bind a
+  MAC to DHCP options; they double as the "is this rule for THIS device"
+  selector, so nothing about the nftables (packet accounting/blocking) or tc
+  (speed shaping) subsystems changes.
+
+This module never touches nftables or tc. It only renders two extra files
+inside dnsmasq's already-active ``conf-dir`` (``/etc/dnsmasq.d`` by default)
+and restarts the dnsmasq unit when they actually change. A restart — not a
+SIGHUP — is required for dnsmasq to notice new ``address=``/``server=``/
+``dhcp-host=`` lines, which costs every client a brief (roughly one second)
+DNS blip on a rule change; see ``DnsRuleManager.apply``.
+
+Known, honest limitation: this is DNS-layer filtering. A client using
+DNS-over-HTTPS/TLS to a resolver outside the box (Android Private DNS,
+browser "secure DNS", etc.) or one that hardcodes a destination IP bypasses
+it entirely, the same way it already bypasses the box's regular DNS. Nothing
+here changes that; it is called out so it is not sold as airtight.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+log = logging.getLogger("quota.dns_rules")
+
+SCOPE_GLOBAL = "global"
+SCOPE_USER = "user"
+SCOPE_DEVICE = "device"
+
+ACTION_BLOCK = "block"
+ACTION_ALLOW = "allow"
+ACTION_REDIRECT = "redirect"
+
+_SCOPE_ORDER = {SCOPE_GLOBAL: 0, SCOPE_USER: 1, SCOPE_DEVICE: 2}
+
+
+# ---------------------------------------------------------------------------
+# Built-in presets — curated, ready-to-use blocklists
+# ---------------------------------------------------------------------------
+# Sources are HOSTS-format ("0.0.0.0 domain" / "127.0.0.1 domain") or
+# AdBlock-Plus-format ("||domain^") text; both are reduced to a flat domain
+# set by compile_source_text. Only network-address-shaped ABP rules survive
+# the conversion — element-hiding/path/regex rules have no DNS-layer
+# equivalent and are dropped (see parse_adblock_plus).
+
+@dataclass
+class Preset:
+    id: str
+    name: str
+    description: str
+    urls: list[str] = field(default_factory=list)
+    format: str = "auto"  # "hosts" | "adblock" | "auto" (sniff per source)
+
+
+PRESETS: dict[str, Preset] = {}
+
+
+def _register(p: Preset) -> None:
+    PRESETS[p.id] = p
+
+
+_register(Preset(
+    id="ads-tracking",
+    name="Ads & tracking",
+    description="General-purpose ads + tracking hosts blocklist (StevenBlack/hosts).",
+    urls=["https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"],
+    format="hosts",
+))
+_register(Preset(
+    id="social-media",
+    name="Social media",
+    description=("Facebook/Instagram/TikTok/Twitter/Discord and friends "
+                 "(cyb3rko/social-media-hosts-blocklists)."),
+    urls=[
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/facebookhosts.txt",
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/instagramhosts.txt",
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/tiktokhosts.txt",
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/twitterhosts.txt",
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/discordhosts.txt",
+    ],
+    format="hosts",
+))
+_register(Preset(
+    id="streaming",
+    name="Streaming & video",
+    description=("Common video-streaming platforms (Netflix, YouTube, Twitch, "
+                 "Prime/Disney+/Hulu/HBO Max, Spotify) — curated inline, see "
+                 "STREAMING_DOMAINS below (no single well-maintained upstream "
+                 "list exists for this category)."),
+    urls=[],
+    format="hosts",
+))
+_register(Preset(
+    id="gambling",
+    name="Gambling",
+    description="Online gambling / betting sites (StevenBlack/hosts alternates).",
+    urls=["https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/gambling-only/hosts"],
+    format="hosts",
+))
+
+#: Curated inline list for the "streaming" preset — reused whenever a preset
+#: has no ``urls`` (see :func:`fetch_preset`).
+STREAMING_DOMAINS: set[str] = {
+    "netflix.com", "nflxvideo.net", "nflximg.net", "nflxso.net", "nflxext.com",
+    "youtube.com", "googlevideo.com", "ytimg.com", "youtu.be",
+    "twitch.tv", "ttvnw.net", "jtvnw.net",
+    "primevideo.com", "amazonvideo.com",
+    "disneyplus.com", "dssott.com",
+    "hulu.com", "hbomax.com", "max.com",
+    "spotify.com", "scdn.co",
+}
+
+
+# ---------------------------------------------------------------------------
+# Parsing: hosts-format and AdBlock-Plus-format -> a flat domain set
+# ---------------------------------------------------------------------------
+
+_HOSTS_LINE_RE = re.compile(
+    r"^\s*(?:0\.0\.0\.0|127\.0\.0\.1|::1)\s+([A-Za-z0-9.\-_]+)")
+_ABP_DOMAIN_RE = re.compile(r"^\|\|([A-Za-z0-9.\-_]+)\^")
+_HOSTS_SKIP = {
+    "localhost", "localhost.localdomain", "local", "broadcasthost",
+    "ip6-localhost", "ip6-loopback", "ip6-localnet", "ip6-mcastprefix",
+    "ip6-allnodes", "ip6-allrouters", "ip6-allhosts",
+}
+
+
+def parse_hosts_format(text: str) -> set[str]:
+    """Extract blocked domains from an ``/etc/hosts``-style blocklist.
+
+    Recognises ``0.0.0.0 domain`` / ``127.0.0.1 domain`` / ``::1 domain``
+    lines. Comments (``#``) and blank lines are ignored, and the handful of
+    loopback aliases every hosts file carries are skipped so they never end
+    up as a generated dnsmasq blackhole.
+    """
+    out: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        m = _HOSTS_LINE_RE.match(line)
+        if not m:
+            continue
+        domain = m.group(1).lower().strip(".")
+        if domain and domain not in _HOSTS_SKIP:
+            out.add(domain)
+    return out
+
+
+def parse_adblock_plus(text: str) -> set[str]:
+    """Extract the network-address-shaped rules from an AdBlock-Plus list.
+
+    Only ``||domain^`` (optionally followed by ``$options``) rules translate
+    to DNS-layer blocking. Element-hiding (``##``/``#@#``), path/regex rules,
+    and exception rules (``@@``) have no DNS-layer equivalent and are
+    dropped — this recovers a subset of what the list author intended, which
+    is the honest ceiling of what a DNS blocker can enforce from an ABP list.
+    """
+    out: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(("!", "[")):
+            continue
+        if line.startswith("@@"):
+            continue  # exception rule — never something to BLOCK
+        m = _ABP_DOMAIN_RE.match(line)
+        if not m:
+            continue
+        domain = m.group(1).lower().strip(".")
+        if domain:
+            out.add(domain)
+    return out
+
+
+def compile_source_text(text: str, fmt: str = "auto") -> set[str]:
+    """Parse one fetched/pasted blocklist, sniffing the format if needed."""
+    if fmt == "hosts":
+        return parse_hosts_format(text)
+    if fmt == "adblock":
+        return parse_adblock_plus(text)
+    domains = parse_hosts_format(text)
+    if domains:
+        return domains
+    return parse_adblock_plus(text)
+
+
+_DOMAIN_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?"
+                        r"(\.[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?)+$")
+
+
+def normalize_pattern(pattern: str) -> str:
+    """Normalize a user-entered domain pattern to what dnsmasq can enforce.
+
+    dnsmasq's ``address=/domain/`` match already covers the domain AND every
+    subdomain of it — that IS the "wildcard" support dnsmasq has. A leading
+    ``*.`` is therefore just stripped (dnsmasq cannot narrow a match to
+    "subdomains only, not the apex" — there is no syntax for that). Any
+    OTHER ``*`` (mid-label, e.g. ``*.ads.*.example.com``) is rejected rather
+    than silently accepted and never actually blocking anything.
+    """
+    p = pattern.strip().lower().rstrip(".")
+    if p.startswith("*."):
+        p = p[2:]
+    if not p or "*" in p or not _DOMAIN_RE.match(p):
+        raise ValueError(
+            f"unsupported domain pattern {pattern!r} — dnsmasq can only "
+            "match a plain domain (the match already includes every "
+            "subdomain); mid-label wildcards are not enforceable at the "
+            "DNS layer")
+    return p
+
+
+def fetch_url(url: str, timeout: float = 20.0) -> str:
+    """Best-effort fetch of a preset source. Raises on failure — the caller
+    decides whether that should keep a previously cached list."""
+    req = urllib.request.Request(url, headers={"User-Agent": "QuotaManager"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def fetch_preset(preset: Preset) -> set[str]:
+    """Fetch + parse every source URL of a preset into one domain set.
+
+    A preset with no ``urls`` (currently only "streaming") uses its curated
+    inline list instead. One failing source is logged and skipped rather
+    than failing the whole preset.
+    """
+    if not preset.urls:
+        if preset.id == "streaming":
+            return set(STREAMING_DOMAINS)
+        return set()
+    domains: set[str] = set()
+    for url in preset.urls:
+        try:
+            text = fetch_url(url)
+        except Exception:  # noqa: BLE001 — one bad source must not kill the rest
+            log.warning("failed to fetch preset source %s", url, exc_info=True)
+            continue
+        domains |= compile_source_text(text, preset.format)
+    return domains
+
+
+# ---------------------------------------------------------------------------
+# Rendering: DB rows -> dnsmasq config text
+# ---------------------------------------------------------------------------
+
+def device_tag(device_id: int) -> str:
+    """The dnsmasq DHCP tag a device is bound to (stable per device id)."""
+    return f"qmdev{device_id}"
+
+
+def render_tags(devices: Iterable[Any]) -> str:
+    """Bind every known MAC to its own DHCP tag (``qmdev<id>``).
+
+    This is what makes per-device rules possible at all: dnsmasq selects
+    config lines by tag, and a tag is assigned per-MAC via ``dhcp-host``.
+    Written to its own file (kept separate from :func:`render_rules`'s
+    output) so a domain-rule edit — which happens far more often than a
+    device being added — never rewrites this file too.
+    """
+    lines = [
+        "# Quota Manager — generated, do not edit by hand.",
+        "# Binds every known device MAC to its own dnsmasq tag so domain",
+        "# rules / DNS-server overrides can be scoped per device or per user.",
+    ]
+    for dev in devices:
+        mac = getattr(dev, "mac", None)
+        dev_id = getattr(dev, "id", None)
+        if not mac or dev_id is None or not _is_safe_config_token(mac):
+            continue
+        lines.append(f"dhcp-host={mac},set:{device_tag(dev_id)}")
+    return "\n".join(lines) + "\n"
+
+
+def _tags_for(scope: str, scope_id: Optional[int],
+             device_ids_by_user: dict[int, list[int]]) -> list[Optional[str]]:
+    """Every dnsmasq tag a rule/server override at this scope expands to.
+
+    ``global`` has no tag (applies to everyone). ``device`` is exactly one
+    tag. ``user`` expands to one tag PER device that user currently owns —
+    dnsmasq only understands per-device tags, so a user-level rule/override
+    is fanned out to every device belonging to that user at render time
+    (mirrors how ``service.resolve_device_state`` fans a user-level admin
+    cut out to devices, just at the DNS layer instead of nftables).
+    """
+    if scope == SCOPE_GLOBAL:
+        return [None]
+    if scope == SCOPE_DEVICE:
+        return [device_tag(scope_id)] if scope_id is not None else []
+    if scope == SCOPE_USER:
+        return [device_tag(d) for d in device_ids_by_user.get(scope_id, [])]
+    return []
+
+
+def _is_safe_config_token(value: str) -> bool:
+    """True if ``value`` cannot break out of a single generated config line.
+
+    Defense in depth: the API layer (api/schemas.py) already validates
+    ``target_ip``/``dns_server`` as bare IP addresses before they ever reach
+    here, but the renderer must never trust that as the ONLY gate — a future
+    caller of render_rules/render_tags that skips the API (a script, a
+    future non-HTTP path) must not be able to smuggle a newline into a
+    dnsmasq directive. Rejects any whitespace/control character.
+    """
+    return bool(value) and value == value.strip() and "\n" not in value \
+        and "\r" not in value and not any(c.isspace() for c in value)
+
+
+def render_rules(rules: Iterable[Any], dns_servers: Iterable[tuple[str, Optional[int], str]],
+                 device_ids_by_user: dict[int, list[int]]) -> str:
+    """Render domain rules (block/allow/redirect) + per-client DNS-server
+    overrides into one dnsmasq config file.
+
+    ``rules`` are DomainRule-like objects (``scope``/``scope_id``/``action``/
+    ``domain``/``target_ip``/``enabled``). ``dns_servers`` are
+    ``(scope, scope_id, ip)`` triples for the per-user/per-device
+    upstream-DNS-server feature.
+
+    Ordering: rules are rendered global-first, then user-scope, then
+    device-scope, and within the same scope, block/redirect before allow.
+    For an EXACT-same-domain-string conflict, dnsmasq's own behaviour is
+    "the later directive for that tag wins", so this ordering lets a
+    narrower scope (or an allow rule) override a broader one. It does NOT
+    matter for the common case of allowing a more specific subdomain of a
+    blocked parent domain — dnsmasq's longest-match already picks the more
+    specific rule regardless of file order.
+    """
+    lines = [
+        "# Quota Manager — generated, do not edit by hand.",
+        "# Domain rules (block/allow/redirect) + per-client DNS-server overrides.",
+    ]
+
+    ordered = sorted(
+        rules,
+        key=lambda r: (
+            _SCOPE_ORDER.get(getattr(r, "scope", SCOPE_GLOBAL), 0),
+            1 if getattr(r, "action", ACTION_BLOCK) == ACTION_ALLOW else 0,
+        ),
+    )
+
+    for rule in ordered:
+        if not getattr(rule, "enabled", True):
+            continue
+        action = getattr(rule, "action", ACTION_BLOCK)
+        domain = getattr(rule, "domain", "")
+        if not domain or not _is_safe_config_token(domain):
+            log.warning("skipping domain rule with unsafe/empty domain %r", domain)
+            continue
+        scope = getattr(rule, "scope", SCOPE_GLOBAL)
+        scope_id = getattr(rule, "scope_id", None)
+        if action == ACTION_ALLOW:
+            target: Optional[str] = None  # no override -> resolves normally
+        elif action == ACTION_REDIRECT:
+            target = getattr(rule, "target_ip", None) or "0.0.0.0"
+            if not _is_safe_config_token(target):
+                log.warning("skipping redirect rule with unsafe target_ip %r "
+                          "for domain %s", target, domain)
+                continue
+        else:  # block
+            target = "0.0.0.0"
+        for tag in _tags_for(scope, scope_id, device_ids_by_user):
+            prefix = f"tag:{tag} " if tag else ""
+            if target is None:
+                # Re-point the domain at the normal upstream chain for this
+                # tag scope, clearing any broader-scope blackhole for it.
+                lines.append(f"{prefix}server=/{domain}/#")
+            else:
+                lines.append(f"{prefix}address=/{domain}/{target}")
+
+    for scope, scope_id, ip in dns_servers:
+        if not ip or not _is_safe_config_token(ip):
+            if ip:
+                log.warning("skipping DNS-server override with unsafe value %r", ip)
+            continue
+        for tag in _tags_for(scope, scope_id, device_ids_by_user):
+            prefix = f"tag:{tag} " if tag else ""
+            lines.append(f"{prefix}server={ip}")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# The manager: writes the two files, reloads dnsmasq only when something
+# actually changed (same signature-gated pattern as the nftables blocked set
+# and the tc tree — see Structure_README.md "Key design decisions").
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DnsRuleManager:
+    conf_dir: str = "/etc/dnsmasq.d"
+    tags_file: str = "quota-tags.conf"
+    rules_file: str = "quota-domains.conf"
+    reload_dnsmasq: bool = True
+
+    def _write_if_changed(self, path: Path, content: str) -> bool:
+        try:
+            if path.exists() and path.read_text(encoding="utf-8") == content:
+                return False
+        except OSError:
+            pass
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            log.error("could not write %s: %s (run as root on the gateway?)",
+                      path, exc)
+            return False
+        return True
+
+    def apply(self, devices: Iterable[Any], rules: Iterable[Any],
+             dns_servers: Iterable[tuple[str, Optional[int], str]],
+             device_ids_by_user: dict[int, list[int]]) -> bool:
+        """Render + write both files. Reloads dnsmasq only if a file's
+        content actually changed. Returns True if a reload was triggered."""
+        tags_text = render_tags(devices)
+        rules_text = render_rules(rules, dns_servers, device_ids_by_user)
+        tags_path = Path(self.conf_dir) / self.tags_file
+        rules_path = Path(self.conf_dir) / self.rules_file
+        tags_changed = self._write_if_changed(tags_path, tags_text)
+        rules_changed = self._write_if_changed(rules_path, rules_text)
+        changed = tags_changed or rules_changed
+        if changed and self.reload_dnsmasq:
+            self._reload()
+        return changed
+
+    def _reload(self) -> None:
+        # `dnsmasq --test` validates the WHOLE effective config (base file +
+        # every conf-dir file), the same check the setup script runs after
+        # writing quota-gateway.conf. Everything this module writes comes
+        # from normalize_pattern-validated input, so a failure here would
+        # mean a bug — but a bad config must never be allowed to take DHCP +
+        # DNS down for the whole household, so this is a hard gate.
+        try:
+            probe = subprocess.run(
+                ["dnsmasq", "--test"], capture_output=True, text=True, timeout=10)
+            if probe.returncode != 0:
+                log.error("generated dnsmasq config failed validation — NOT "
+                          "reloading: %s", probe.stderr.strip())
+                return
+        except FileNotFoundError:
+            log.warning("`dnsmasq` binary not found — skipping the pre-reload "
+                       "validation check (reloading anyway)")
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.warning("could not run `dnsmasq --test` (%s) — reloading anyway", exc)
+        try:
+            subprocess.run(["systemctl", "restart", "dnsmasq"],
+                           capture_output=True, text=True, timeout=15, check=True)
+            log.info("dnsmasq restarted to apply DNS filtering rule changes")
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.error("failed to restart dnsmasq after a DNS rule change: %s", exc)

--- a/run.py
+++ b/run.py
@@ -41,6 +41,7 @@ from api.app import create_app
 from core import config as cfg_mod
 from core.logging_setup import setup_logging
 from quota import db as _db
+from quota import dns_rules as _dns_rules
 from quota.arp_scan import ArpScanner
 from quota.engine import GATEWAY_MAC, EngineSnapshot, SnapshotHolder
 from quota.netmgr import TopologyManager
@@ -70,6 +71,20 @@ def _make_shaper(cfg: cfg_mod.Config):
                     "speed limits + low-latency queues off")
         return None
     return TcShaper(cfg)
+
+
+def _make_dns_manager(cfg: cfg_mod.Config) -> _dns_rules.DnsRuleManager | None:
+    """Build the DNS-filtering config writer, or None when disabled."""
+    dns_cfg = getattr(cfg, "dns_filter", None)
+    if dns_cfg is not None and not dns_cfg.enabled:
+        log.warning("DNS filtering disabled in config — domain rules, "
+                    "presets, and per-client DNS-server overrides are inert")
+        return None
+    if dns_cfg is None:
+        return _dns_rules.DnsRuleManager()
+    return _dns_rules.DnsRuleManager(
+        conf_dir=dns_cfg.conf_dir, tags_file=dns_cfg.tags_file,
+        rules_file=dns_cfg.rules_file, reload_dnsmasq=dns_cfg.reload_dnsmasq)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -107,6 +122,7 @@ class Gateway:
         self.holder = SnapshotHolder()
         self.engine: NftablesEngine | None = None
         self.shaper: object | None = None  # quota.shaping.TcShaper (tc/ifb)
+        self.dns_manager: _dns_rules.DnsRuleManager | None = None  # domain filtering
         self.arp_lock: object | None = None  # quota.arp_lock.ArpLock (opt-in)
         # Built in startup(), AFTER the DB topology override: the scanner
         # resolves its probe networks from cfg at construction, so building it
@@ -133,6 +149,10 @@ class Gateway:
         #: briefly undo the user's fresh caps. Whoever runs second re-reads the
         #: DB, so the lock makes both orderings end on the fresh state.
         self._shaping_lock = asyncio.Lock()
+        #: serializes DNS-rule regeneration the same way ``_shaping_lock``
+        #: does for the tc tree (a maintenance tick and an API-triggered
+        #: immediate apply must not race each other's DB read + file write).
+        self._dns_lock = asyncio.Lock()
         self._maintenance_task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
 
@@ -172,6 +192,15 @@ class Gateway:
         self.shaper = _make_shaper(self.cfg)
         if self.shaper is not None:
             self.shaper.start()
+
+        # -- DNS filtering (dnsmasq domain rules + per-client DNS servers) --
+        # Pure config-generation, no kernel/socket state to "start" — built
+        # here (not __init__) for symmetry with the shaper/engine and so a
+        # future config-driven rebuild has the same lifecycle shape. An
+        # initial apply happens after the maintenance loop's first tick
+        # (device tags need a device list, which _sync_dnsmasq_leases fills
+        # in), not here — see _maintenance_tick.
+        self.dns_manager = _make_dns_manager(self.cfg)
 
         # -- ARP gateway-lock (opt-in) ---------------------------------------
         # Deny internet to devices that bypass the box by using the ROUTER as
@@ -476,6 +505,12 @@ class Gateway:
         #    touch the kernel; a DB edit lands here within one tick (<=15 s).
         await self._sync_shaping(ip_to_mac)
 
+        # 6. Regenerate dnsmasq's domain-rule + tag config if anything
+        #    changed (new device -> new tag, or a rule/preset/DNS-server
+        #    edit that arrived without going through the API's immediate
+        #    apply — e.g. a test or a future non-HTTP caller).
+        await self._sync_dns_rules()
+
     async def _sync_shaping(self, ip_to_mac: dict[str, str]) -> None:
         """Push the latest shaping settings + device caps into the tc shaper.
 
@@ -525,6 +560,51 @@ class Gateway:
             await self._sync_shaping(self._last_ip_to_mac)
         except Exception:  # noqa: BLE001
             log.exception("failed to apply speed-limit change immediately")
+
+    async def _sync_dns_rules(self) -> None:
+        """Regenerate the dnsmasq domain-rule + tag config from the DB and
+        reload dnsmasq if anything changed.
+
+        Mirrors ``_sync_shaping``: reads devices/users/rules fresh every
+        call and lets ``DnsRuleManager.apply`` decide (by content diff)
+        whether a reload is actually needed, so a call with nothing new to
+        say is free. Called once per maintenance tick (new devices need a
+        tag even with no rule edits) and immediately after any DNS-related
+        API edit via ``_apply_dns_now``.
+        """
+        manager = self.dns_manager
+        if manager is None:
+            return
+        try:
+            async with self._dns_lock:
+                devices = await self.database.list_devices()
+                users = {u.id: u for u in await self.database.list_users()}
+                rules = await self.database.list_domain_rules(enabled_only=True)
+                device_ids_by_user: dict[int, list[int]] = {}
+                for dev in devices:
+                    if dev.user_id is not None:
+                        device_ids_by_user.setdefault(dev.user_id, []).append(dev.id)
+                # Per-client DNS-server overrides: a device's own override
+                # wins; otherwise it inherits its user's override (if any).
+                # Rendered as (scope, scope_id, ip) triples, same shape as a
+                # domain rule's scope so render_rules' _tags_for is reused.
+                dns_servers: list[tuple[str, int | None, str]] = []
+                for user in users.values():
+                    if user.dns_server:
+                        dns_servers.append((_db.DNS_SCOPE_USER, user.id, user.dns_server))
+                for dev in devices:
+                    if dev.dns_server:
+                        dns_servers.append((_db.DNS_SCOPE_DEVICE, dev.id, dev.dns_server))
+                await asyncio.to_thread(
+                    manager.apply, devices, rules, dns_servers, device_ids_by_user)
+        except Exception:  # noqa: BLE001
+            log.exception("failed to sync DNS filtering rules")
+
+    async def _apply_dns_now(self) -> None:
+        """Apply a domain-rule / preset / DNS-server edit immediately instead
+        of waiting for the next maintenance tick. The API schedules this
+        after every /api/dns/* and /api/{users,devices}/{id}/dns edit."""
+        await self._sync_dns_rules()
 
     async def _wan_status(self) -> dict[str, object]:
         """Live WAN-mode status for the dashboard/API (cheap, every 15 s tick).
@@ -649,7 +729,8 @@ def main() -> None:
                          log_path=cfg.log_file,
                          topology_manager=gateway.topology_manager,
                          shaping_sync=gateway._reshaping_now,
-                         report_config=report_cfg)
+                         report_config=report_cfg,
+                         dns_apply=gateway._apply_dns_now)
         server_config = uvicorn.Config(
             app,
             host=cfg.web.host,

--- a/scripts/setup_gateway_kali.sh
+++ b/scripts/setup_gateway_kali.sh
@@ -477,6 +477,25 @@ else
     warn "dnsmasq config did not validate — fix it before starting the app"
 fi
 
+# --- 4b. dnsmasq: domain-filtering base files (blacklists/DNS overrides) ----
+# quota/dns_rules.py (the DNS-filtering feature) writes generated rules into
+# these two files whenever the admin edits a domain rule / preset / per-client
+# DNS server in the dashboard. They start EMPTY here — the app owns their
+# content from the first rule onward — this step only guarantees they exist
+# so a stock Debian/Kali install (which ships `conf-dir=/etc/dnsmasq.d` in
+# /etc/dnsmasq.conf by default) picks them up without any extra config.
+log "[4b/8] preparing dnsmasq domain-filtering files (empty until rules are added)"
+for f in quota-tags.conf quota-domains.conf; do
+    [ -f "/etc/dnsmasq.d/$f" ] || printf '# Quota Manager — generated, do not edit by hand.\n' \
+        > "/etc/dnsmasq.d/$f"
+done
+# Belt-and-braces: explicitly enable conf-dir in case /etc/dnsmasq.conf was
+# customized to NOT already include it (the Debian/Kali package default does).
+if ! grep -q '^conf-dir=/etc/dnsmasq\.d' /etc/dnsmasq.conf 2>/dev/null; then
+    echo 'conf-dir=/etc/dnsmasq.d/,*.conf' >> /etc/dnsmasq.conf
+    log "   added conf-dir=/etc/dnsmasq.d to /etc/dnsmasq.conf (was missing)"
+fi
+
 # --- 5. nftables: NAT for the client subnet ----------------------------------
 log "[5/8] writing nftables NAT ruleset"
 # The app (run.py, quota/nftables.py) owns the `inet quota_gateway` table —

--- a/tests/test_dns_rules.py
+++ b/tests/test_dns_rules.py
@@ -1,0 +1,350 @@
+"""Tests for quota/dns_rules.py: hosts/AdBlock-Plus parsing, wildcard
+normalization, and the dnsmasq tag/rule renderer + file-writing manager.
+
+Pure-function tests (parsing, normalization, rendering) need no root, no
+dnsmasq, and no network — they only assert on generated text. The
+DnsRuleManager tests use a tmp_path conf_dir and reload_dnsmasq=False so they
+never shell out to `dnsmasq`/`systemctl` (mirrors how test_shaping.py avoids
+touching the real `tc` binary).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from quota import dns_rules as dr
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+def test_parse_hosts_format_extracts_domains():
+    text = (
+        "# comment\n"
+        "0.0.0.0 ads.example.com\n"
+        "127.0.0.1 tracker.example.net  # inline comment\n"
+        "0.0.0.0 localhost\n"          # must be skipped
+        "not a hosts line\n"
+        "\n"
+    )
+    assert dr.parse_hosts_format(text) == {"ads.example.com", "tracker.example.net"}
+
+
+def test_parse_adblock_plus_extracts_domain_rules_only():
+    text = (
+        "! this is a comment\n"
+        "[Adblock Plus 2.0]\n"
+        "||ads.example.com^\n"
+        "||tracker.example.net^$third-party\n"
+        "@@||safe.example.com^\n"          # exception — must NOT be blocked
+        "##.ad-banner\n"                    # element-hiding — no DNS equivalent
+        "/some/path/rule\n"                 # path rule — no DNS equivalent
+    )
+    assert dr.parse_adblock_plus(text) == {"ads.example.com", "tracker.example.net"}
+
+
+def test_compile_source_text_auto_detects_format():
+    hosts_text = "0.0.0.0 ads.example.com\n"
+    abp_text = "||ads.example.com^\n"
+    assert dr.compile_source_text(hosts_text, "auto") == {"ads.example.com"}
+    assert dr.compile_source_text(abp_text, "auto") == {"ads.example.com"}
+
+
+# ---------------------------------------------------------------------------
+# Wildcard / pattern normalization
+# ---------------------------------------------------------------------------
+
+def test_normalize_pattern_strips_leading_wildcard():
+    # dnsmasq's domain match already includes every subdomain, so "*." is
+    # just a no-op on top of the plain-domain match — stripped, not kept.
+    assert dr.normalize_pattern("*.example.com") == "example.com"
+    assert dr.normalize_pattern("EXAMPLE.com.") == "example.com"
+
+
+def test_normalize_pattern_rejects_midlabel_wildcard():
+    # Not something dnsmasq's exact-domain match can enforce.
+    with pytest.raises(ValueError):
+        dr.normalize_pattern("*.ads.*.example.com")
+    with pytest.raises(ValueError):
+        dr.normalize_pattern("ads*.example.com")
+
+
+def test_normalize_pattern_rejects_empty_or_garbage():
+    with pytest.raises(ValueError):
+        dr.normalize_pattern("")
+    with pytest.raises(ValueError):
+        dr.normalize_pattern("not a domain!!")
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeDevice:
+    id: int
+    mac: str
+
+
+@dataclass
+class _FakeRule:
+    scope: str
+    scope_id: Optional[int]
+    action: str
+    domain: str
+    target_ip: Optional[str] = None
+    enabled: bool = True
+
+
+def test_render_tags_binds_every_device_mac():
+    devices = [_FakeDevice(1, "aa:bb:cc:dd:ee:01"), _FakeDevice(2, "aa:bb:cc:dd:ee:02")]
+    text = dr.render_tags(devices)
+    assert "dhcp-host=aa:bb:cc:dd:ee:01,set:qmdev1" in text
+    assert "dhcp-host=aa:bb:cc:dd:ee:02,set:qmdev2" in text
+
+
+def test_render_rules_global_block_has_no_tag_prefix():
+    rules = [_FakeRule("global", None, "block", "ads.example.com")]
+    text = dr.render_rules(rules, [], {})
+    assert "address=/ads.example.com/0.0.0.0" in text
+    assert "tag:" not in text
+
+
+def test_render_rules_device_scope_is_tag_restricted():
+    rules = [_FakeRule("device", 7, "block", "tiktok.com")]
+    text = dr.render_rules(rules, [], {})
+    assert "tag:qmdev7 address=/tiktok.com/0.0.0.0" in text
+
+
+def test_render_rules_user_scope_fans_out_to_every_owned_device():
+    rules = [_FakeRule("user", 42, "block", "netflix.com")]
+    device_ids_by_user = {42: [1, 2, 3]}
+    text = dr.render_rules(rules, [], device_ids_by_user)
+    for dev_id in (1, 2, 3):
+        assert f"tag:qmdev{dev_id} address=/netflix.com/0.0.0.0" in text
+
+
+def test_render_rules_redirect_uses_target_ip():
+    rules = [_FakeRule("global", None, "redirect", "printer.local", target_ip="192.168.2.50")]
+    text = dr.render_rules(rules, [], {})
+    assert "address=/printer.local/192.168.2.50" in text
+
+
+def test_render_rules_rejects_config_injection_in_target_ip():
+    # Defense in depth: even if a malformed target_ip somehow reaches the
+    # renderer (the API layer should already reject it — see
+    # test_api_rejects_config_injection_in_target_ip below), it must never
+    # be written verbatim into a line dnsmasq will parse as two directives.
+    rules = [_FakeRule("global", None, "redirect", "evil.example.com",
+                       target_ip="1.1.1.1\nno-resolv")]
+    text = dr.render_rules(rules, [], {})
+    assert "no-resolv" not in text
+    assert "evil.example.com" not in text  # the whole rule is dropped, not truncated
+
+
+def test_render_rules_rejects_config_injection_in_dns_server():
+    text = dr.render_rules([], [("device", 5, "1.1.1.1\nserver=evil")], {})
+    assert "evil" not in text
+
+
+def test_render_rules_disabled_rule_is_skipped():
+    rules = [_FakeRule("global", None, "block", "ads.example.com", enabled=False)]
+    text = dr.render_rules(rules, [], {})
+    assert "ads.example.com" not in text
+
+
+def test_render_rules_allow_renders_after_block_for_override():
+    # A device-scoped allow for the SAME domain as a global block must come
+    # after it in the file so dnsmasq's "last directive wins" gives the
+    # allow priority for that exact device.
+    rules = [
+        _FakeRule("global", None, "block", "example.com"),
+        _FakeRule("device", 3, "allow", "example.com"),
+    ]
+    text = dr.render_rules(rules, [], {})
+    block_idx = text.index("address=/example.com/0.0.0.0")
+    allow_idx = text.index("tag:qmdev3 server=/example.com/#")
+    assert block_idx < allow_idx
+
+
+def test_render_rules_dns_server_overrides():
+    text = dr.render_rules([], [("device", 5, "1.1.1.1"), ("global", None, "9.9.9.9")], {})
+    assert "tag:qmdev5 server=1.1.1.1" in text
+    assert "server=9.9.9.9" in text
+
+
+# ---------------------------------------------------------------------------
+# DnsRuleManager (file writing, no real dnsmasq/systemctl involved)
+# ---------------------------------------------------------------------------
+
+def test_manager_writes_both_files(tmp_path: Path):
+    manager = dr.DnsRuleManager(conf_dir=str(tmp_path), reload_dnsmasq=False)
+    devices = [_FakeDevice(1, "aa:bb:cc:dd:ee:01")]
+    rules = [_FakeRule("global", None, "block", "ads.example.com")]
+    changed = manager.apply(devices, rules, [], {})
+    assert changed is True
+    assert (tmp_path / "quota-tags.conf").exists()
+    assert (tmp_path / "quota-domains.conf").exists()
+    assert "qmdev1" in (tmp_path / "quota-tags.conf").read_text()
+    assert "ads.example.com" in (tmp_path / "quota-domains.conf").read_text()
+
+
+def test_manager_apply_is_signature_gated(tmp_path: Path):
+    """A second identical apply() must report no change (nothing to
+    reload) — same pattern as the nftables blocked set / tc tree."""
+    manager = dr.DnsRuleManager(conf_dir=str(tmp_path), reload_dnsmasq=False)
+    devices = [_FakeDevice(1, "aa:bb:cc:dd:ee:01")]
+    rules = [_FakeRule("global", None, "block", "ads.example.com")]
+    assert manager.apply(devices, rules, [], {}) is True
+    assert manager.apply(devices, rules, [], {}) is False  # unchanged
+    rules2 = [_FakeRule("global", None, "block", "tracker.example.net")]
+    assert manager.apply(devices, rules2, [], {}) is True  # content changed
+
+
+# ---------------------------------------------------------------------------
+# Presets registry sanity
+# ---------------------------------------------------------------------------
+
+def test_streaming_preset_has_no_urls_and_uses_curated_list():
+    preset = dr.PRESETS["streaming"]
+    assert preset.urls == []
+    assert dr.fetch_preset(preset) == dr.STREAMING_DOMAINS
+
+
+def test_social_media_preset_lists_cyb3rko_sources():
+    preset = dr.PRESETS["social-media"]
+    assert any("cyb3rko/social-media-hosts-blocklists" in u for u in preset.urls)
+
+
+# ---------------------------------------------------------------------------
+# DB-layer CRUD (quota/db.py's domain_rules / dns_presets / dns_server cols)
+# ---------------------------------------------------------------------------
+
+import asyncio  # noqa: E402  (grouped with the DB-test section, not the top)
+
+from quota import db as _db  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_domain_rule_crud_roundtrip(tmp_path: Path):
+    async def _body():
+        database = _db.Database(tmp_path / "q.db")
+        await database.connect()
+        rule = await database.create_domain_rule(
+            "global", "block", "ads.example.com")
+        assert rule.id > 0
+        assert rule.source == "manual"
+
+        fetched = await database.get_domain_rule(rule.id)
+        assert fetched is not None and fetched.domain == "ads.example.com"
+
+        listed = await database.list_domain_rules()
+        assert len(listed) == 1
+
+        await database.update_domain_rule(rule.id, enabled=False)
+        disabled = await database.get_domain_rule(rule.id)
+        assert disabled.enabled is False
+
+        await database.delete_domain_rule(rule.id)
+        assert await database.get_domain_rule(rule.id) is None
+        await database.close()
+    _run(_body())
+
+
+def test_domain_rule_scoped_delete_on_device_removal(tmp_path: Path):
+    async def _body():
+        database = _db.Database(tmp_path / "q.db")
+        await database.connect()
+        dev = await database.upsert_device("aa:bb:cc:dd:ee:01", name="phone")
+        await database.create_domain_rule(
+            "device", "block", "tiktok.com", scope_id=dev.id)
+        assert len(await database.list_domain_rules()) == 1
+        await database.delete_device(dev.id)
+        # The device-scoped rule is orphaned once its device (and dnsmasq
+        # tag) is gone, so delete_device sweeps it too.
+        assert await database.list_domain_rules() == []
+        await database.close()
+    _run(_body())
+
+
+def test_device_and_user_dns_server_persist(tmp_path: Path):
+    async def _body():
+        database = _db.Database(tmp_path / "q.db")
+        await database.connect()
+        user = await database.create_user(name="kid")
+        await database.update_user(user.id, dns_server="1.1.1.3")
+        refreshed = await database.get_user(user.id)
+        assert refreshed.dns_server == "1.1.1.3"
+
+        dev = await database.upsert_device("aa:bb:cc:dd:ee:02", name="tablet",
+                                           user_id=user.id)
+        await database.update_device(dev.id, dns_server="9.9.9.9")
+        refreshed_dev = await database.get_device(dev.id)
+        assert refreshed_dev.dns_server == "9.9.9.9"
+        await database.close()
+    _run(_body())
+
+
+def test_preset_state_roundtrip(tmp_path: Path):
+    async def _body():
+        database = _db.Database(tmp_path / "q.db")
+        await database.connect()
+        assert await database.get_preset_state("ads-tracking") is None
+        await database.set_preset_state("ads-tracking", True, domain_count=1234)
+        state = await database.get_preset_state("ads-tracking")
+        assert state["enabled"] == 1
+        assert state["domain_count"] == 1234
+        await database.set_preset_state("ads-tracking", False, domain_count=0)
+        state = await database.get_preset_state("ads-tracking")
+        assert state["enabled"] == 0
+        await database.close()
+    _run(_body())
+
+
+# ---------------------------------------------------------------------------
+# API-layer validation (api/schemas.py) — the FIRST line of defense against
+# config injection via target_ip / dns_server; quota/dns_rules.py's
+# _is_safe_config_token tests above are the second (defense in depth).
+# ---------------------------------------------------------------------------
+
+def test_api_rejects_config_injection_in_target_ip():
+    from pydantic import ValidationError
+
+    from api.schemas import DomainRuleCreate
+
+    with pytest.raises(ValidationError):
+        DomainRuleCreate(scope="global", action="redirect",
+                         domain="evil.example.com",
+                         target_ip="1.1.1.1\nno-resolv")
+
+
+def test_api_accepts_valid_target_ip():
+    from api.schemas import DomainRuleCreate
+
+    rule = DomainRuleCreate(scope="global", action="redirect",
+                            domain="printer.local", target_ip="192.168.2.50")
+    assert rule.target_ip == "192.168.2.50"
+
+
+def test_api_rejects_config_injection_in_dns_server():
+    from pydantic import ValidationError
+
+    from api.schemas import DnsServerUpdate
+
+    with pytest.raises(ValidationError):
+        DnsServerUpdate(dns_server="1.1.1.1\nserver=evil")
+
+
+def test_api_accepts_empty_dns_server_as_clear():
+    from api.schemas import DnsServerUpdate
+
+    assert DnsServerUpdate(dns_server="").dns_server == ""
+    assert DnsServerUpdate(dns_server="9.9.9.9").dns_server == "9.9.9.9"


### PR DESCRIPTION
Implemented requested features by me in issue #1 as promised, also allowed release workflow to be triggered manually, so now there's also a [test build](https://github.com/ZG089/QuotaManager/releases/tag/v0.1.1) in my forked repo. You can install that, test and tell me your impressions about the new changes.