### PR TITLE
[FOLLOW UP #2] domain filtering, blocklist presets, and DNS overrides

### DIFF
--- a/Structure_README.md
+++ b/Structure_README.md
@@ -17,6 +17,7 @@ the project layout, tests, and the release process.
 - [The maintenance loop](#the-maintenance-loop)
 - [Quota model](#quota-model)
 - [Speed shaping](#speed-shaping)
+- [DNS filtering (domain rules, presets, per-client DNS servers)](#dns-filtering-domain-rules-presets-per-client-dns-servers)
 - [Rogue devices & the ARP gateway-lock](#rogue-devices--the-arp-gateway-lock)
 - [Strong (WAN) mode](#strong-wan-mode)
 - [Key design decisions](#key-design-decisions)
@@ -180,6 +181,17 @@ at *their* `history_days` (NULL = the global `history.retention_days`). See
 the [REST API](#rest-api) `/api/history/{device_id}` row and the
 [Configuration](#configuration) `history:` block.
 
+**Domain filtering + per-client DNS servers** (when `cfg.dns_filter.enabled`,
+default on): `_sync_dns_rules` reads `domain_rules`, every user's/device's
+`dns_server`, and the device list fresh each tick, renders them into two
+files inside dnsmasq's `conf-dir` (`quota-tags.conf` binds every MAC to its
+own DHCP tag; `quota-domains.conf` holds the tag-restricted `address=`/
+`server=` lines), and reloads dnsmasq only when a file's content actually
+changed. The API additionally calls this immediately after any `/api/dns/*`
+or `/api/{users,devices}/{id}/dns` edit, so a rule change does not wait for
+the next tick. See [DNS filtering](#dns-filtering-domain-rules-presets-per-client-dns-servers)
+below for the full design.
+
 ---
 
 ## Quota model
@@ -286,6 +298,109 @@ Two engine-side details worth knowing:
   without creating it, `start()` unloads + reloads with the right `numifbs`.
   The apply itself never re-modprobes — a no-op `modprobe ifb numifbs=1` at
   apply time silently killed shaping on a live box.
+
+---
+
+## DNS filtering (domain rules, presets, per-client DNS servers)
+
+`quota/dns_rules.py` is a **third** generated-config layer, alongside
+nftables (packet accounting/blocking), tc (speed shaping), and
+`quota/dnslog.py` (browsing history) — but it never touches any of the
+other three. It rides entirely on the DHCP+DNS server the box already runs
+(`dnsmasq`), writing two extra files into its `conf-dir` (`/etc/dnsmasq.d`
+by default, alongside `quota-gateway.conf` and `quota-dnslog.conf`):
+
+- **`quota-tags.conf`** — `dhcp-host=<mac>,set:qmdev<id>` for every known
+  device. This is the whole mechanism that makes *per-device* or *per-user*
+  rules possible: dnsmasq selects config lines by DHCP tag, so binding a MAC
+  to a tag is the "is this rule for THIS device" selector.
+- **`quota-domains.conf`** — the actual rules, as tag-restricted
+  `address=/domain/target` (block/redirect) or `server=/domain/#`
+  (allow-list override) lines, plus tag-restricted `server=<ip>` lines for
+  per-user/per-device upstream DNS servers. A user-scoped rule/override is
+  fanned out to one line per device that user currently owns (dnsmasq only
+  understands per-device tags).
+
+```
+domain_rules (DB) ──┐
+dns_presets  (DB) ──┼─► DnsRuleManager.apply() ─► write quota-tags.conf
+users.dns_server ───┤                              write quota-domains.conf
+devices.dns_server ─┘                              (only if content changed)
+                                                            │
+                                                   dnsmasq --test (validate)
+                                                            │
+                                                  systemctl restart dnsmasq
+```
+
+Both files are rewritten and diffed on every maintenance tick and
+immediately after any `/api/dns/*` (or `/api/{users,devices}/{id}/dns`)
+edit — same signature-gated pattern as the nftables blocked set and the tc
+tree: an unchanged render never touches dnsmasq. Unlike a SIGHUP (which only
+re-reads `/etc/hosts` and lease-adjacent files), new `address=`/`server=`/
+`dhcp-host=` lines need a **restart** to take effect, so a rule change costs
+every client a brief (~1 s) DNS blip — acceptable for an admin edit, not
+something that happens on its own.
+
+**Blocklist presets** (`ads-tracking`, `social-media`, `streaming`,
+`gambling`) are curated source lists — hosts-format or AdBlock-Plus-format —
+fetched and compiled down to a flat domain set by `compile_source_text`.
+Enabling one bulk-inserts `domain_rules` rows (one `executemany` + one
+commit — see "Known bottlenecks" below) tagged
+`source='preset:<id>:<scope>:<scope_id>'`; disabling, or re-enabling at a
+**different** scope, deletes exactly those rows so a scope change never
+leaves an orphaned rule set behind. Only the network-address-shaped subset
+of an AdBlock-Plus list (`||domain^`) has a DNS-layer equivalent —
+element-hiding, path, and regex rules are dropped during compilation, which
+is an honest ceiling, not a bug.
+
+**Blacklist/allow-list a domain straight from browsing history**: the
+History tab's per-domain rows carry a live status badge (blocked / allowed /
+redirected / no rule) and one-click "Block this device" / "Block everyone" /
+"Allow" buttons, backed by `POST /api/dns/rules/quick`. The badge is computed
+by `dns_rules.resolve_domain_status`, which mirrors dnsmasq's OWN matching
+exactly rather than approximating it: longest-domain-match wins first (a
+rule for `ads.example.com` beats one for `example.com`, dnsmasq's rule, not
+an ordering choice made here), and ties are broken by the identical
+scope/action ordering `render_rules` renders in (global < user < device;
+allow after block within a scope) — because that ordering IS "last directive
+for this tag wins" in the generated config, the same tiebreak here reports
+the config's actual live behavior.
+
+**SQLite NULL-uniqueness note** (a real bug caught in review, fixed before
+merge): `domain_rules` has `UNIQUE(scope, scope_id, domain, action)` written
+as `UNIQUE(scope, scope_key, domain, action)`, where `scope_key` is a
+generated `COALESCE(scope_id, 0)` column. SQLite treats every `NULL` as
+distinct from every other `NULL`; every global rule has `scope_id IS NULL`,
+so a naive unique constraint on `scope_id` directly never collides for two
+global rows — re-submitting the same global rule silently inserted a
+duplicate instead of updating the existing one. `scope_key` gives the upsert
+a real, non-NULL key to collide on. A DB created by a pre-fix build is
+repaired in place by `Database._migrate_domain_rules_scope_key` (rebuilds
+the table, keeps the newest row per scope/scope_id/domain/action, drops the
+duplicates the old constraint let through).
+
+**Known limitation, by design of the technique**: this is DNS-layer
+filtering. A client using DNS-over-HTTPS/TLS to a resolver outside the box,
+or one that hardcodes a destination IP, bypasses it — the same way it
+already bypasses the box's regular DNS. Nothing about this feature changes
+that.
+
+**Known limitation, parallel to an existing one**: per-device/per-user rules
+and DNS-server overrides depend entirely on the DHCP tag
+(`quota-tags.conf`'s `dhcp-host=<mac>,set:qmdev<id>`), which dnsmasq only
+assigns to a MAC it has actually leased. A **static-IP device is invisible
+to tagging** the exact same way it is already invisible to the per-device
+block enforcement documented in `CLAUDE.md`'s `[LEGACY_DEBT_AND_RISKS]`
+("Per-device block can silently not cut a lease-less device") — a
+per-device/per-user domain rule or DNS-server override on a static-IP
+client silently does nothing, with no error surfaced anywhere.
+**Global-scope rules are unaffected** (no tag needed). The ARP gateway-lock
+(`engine.gateway_arp_lock`) only narrows this: it denies a static-IP device
+that points at the ROUTER as its gateway (the common bypass), but a
+static-IP device that already points at the BOX as its gateway is counted
+and blocked normally by IP yet still never gets a tag — it is not a full
+fix for the tagging gap, the same way it is not a full fix for the
+per-device block gap.
 
 Shaping sits after nftables in the packet path: blocked devices are already
 dropped in `forward`, and counters see the real pre-NAT src / post-NAT dst
@@ -661,6 +776,15 @@ history:
   dnsmasq_log_file: /var/log/quota-dnsmasq.log  # log-facility the setup
                               #   fragment points log-queries=extra at
   retention_days: 7           # global default; a user's "history_days" overrides
+
+dns_filter:
+  enabled: true               # domain rules / presets / per-client DNS servers.
+                              #   false => the feature is entirely inert.
+  conf_dir: /etc/dnsmasq.d    # dnsmasq's conf-dir (Debian/Kali default)
+  tags_file: quota-tags.conf     # per-device DHCP tag bindings (generated)
+  rules_file: quota-domains.conf # domain rules + DNS-server overrides (generated)
+  reload_dnsmasq: true        # restart dnsmasq when the generated files change
+  preset_cache_dir: data/dns_presets
 ```
 
 > **Speed shaping is switched on in the dashboard, not in this YAML.**
@@ -685,7 +809,14 @@ sets a session cookie. The dashboard client uses the same endpoints.
 | GET | `/api/usage/{id}` · `/api/usage` | daily usage series per device / aggregated |
 | GET | `/api/events?limit=30` | audit events |
 | GET | `/api/logs?limit=300` | tail of the rotating log (newest first) |
-| GET | `/api/history/{device_id}?window=24&limit=100` | a device's DNS browsing history — `top_domains`, `activity` (minute buckets), `recent` (latest queries), `total_queries`. Auth-gated; `window` hours clamped 1–336, `limit` capped. Bandwidth is NOT duplicated here — the History tab reads live/per-period bytes from the dashboard payload |
+| GET | `/api/history/{device_id}?window=24&limit=100` | a device's DNS browsing history — `top_domains`, `activity` (minute buckets), `recent` (latest queries), `total_queries`. Auth-gated; `window` hours clamped 1–336, `limit` capped. Bandwidth is NOT duplicated here — the History tab reads live/per-period bytes from the dashboard payload. Every `top_domains`/`recent` row also carries a `status` (`blocked`/`allowed`/`redirected`/`none`) from `dns_rules.resolve_domain_status`, powering the History tab's filter badges + quick-action buttons |
+| GET/POST/PATCH/DELETE | `/api/dns/rules` | domain-filtering rules: list (optionally `?scope=&scope_id=`) / create (`{"scope","scope_id","action":"block"\|"allow"\|"redirect","domain","target_ip"}`) / enable-disable via PATCH / delete |
+| POST | `/api/dns/rules/quick` | one-click block/allow from a History-tab domain row: `{"domain","action":"block"\|"allow","scope":"global"\|"device","device_id"}` |
+| POST | `/api/dns/import` | paste raw hosts-format or AdBlock-Plus-format blocklist text (`{"text","format":"auto"\|"hosts"\|"adblock","scope","scope_id","action"}`) → bulk-creates domain rules in one transaction |
+| GET | `/api/dns/presets` | list built-in blocklist presets (ads-tracking, social-media, streaming, gambling) with their enabled state + domain count |
+| POST | `/api/dns/presets/{id}/enable` · `/disable` | fetch + compile a preset's sources into domain rules for a scope (`{"scope","scope_id"}`), or remove exactly those rules. Re-enabling at a DIFFERENT scope purges the old scope's rules first |
+| POST | `/api/dns/apply` | force an immediate dnsmasq regeneration + reload (normally automatic after every DNS-related edit) |
+| PATCH | `/api/users/{id}/dns` · `/api/devices/{id}/dns` | set/clear a per-user or per-device upstream DNS-server override (`{"dns_server": "1.1.1.1"}`, `""` clears it) |
 | GET/POST | `/api/bundle` | read / update bundle (`total_gb`, `reset_day`, or `add_gb` to recharge mid-month). A POST makes the dashboard the bundle owner (`bundle_source=dashboard`) |
 | POST | `/api/reset-month` | force an early period roll-over |
 | GET/POST | `/api/guest` | guest mode: auto-register new devices with their own small allowance |
@@ -752,6 +883,10 @@ QuotaManager/
 │   │                         #   on the client subnet so bypassers' frames hit the box
 │   ├── dnslog.py             # DNS browsing history: dnsmasq query-log parser +
 │   │                         #   DnslogTailer thread (bounded queue) -> dns_history
+│   ├── dns_rules.py          # DnsRuleManager: domain blacklist/allow/redirect rules,
+│   │                         #   blocklist presets, per-client DNS-server overrides,
+│   │                         #   resolve_domain_status (History-tab filter badges) —
+│   │                         #   generated dnsmasq config, no new service
 │   ├── topology.py           # WAN-topology detection: is ppp0 up (for the WAN tab)?
 │   ├── netmgr.py             # TopologyManager: the WAN tab's live LAN/WAN switch
 │   ├── vendor.py             # MAC OUI -> manufacturer (IEEE registry, lazy load)

--- a/api/app.py
+++ b/api/app.py
@@ -25,12 +25,16 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from contextlib import asynccontextmanager
 
-from api.schemas import (BundleUpdate, DeviceCreate, DeviceUpdate, GuestUpdate,
-                         LoginRequest, MilestoneNotify, NetworkUpdate,
-                         PasswordUpdate, SetupComplete, TopUpRequest,
-                         UserCreate, UserUpdate, WanTest, WanUpdate)
+from api.schemas import (BundleUpdate, DeviceCreate, DeviceUpdate,
+                         DnsImportRequest, DnsPresetEnable, DnsQuickRule,
+                         DnsServerUpdate, DomainRuleCreate, DomainRuleUpdate,
+                         GuestUpdate, LoginRequest, MilestoneNotify,
+                         NetworkUpdate, PasswordUpdate, SetupComplete,
+                         TopUpRequest, UserCreate, UserUpdate, WanTest,
+                         WanUpdate)
 from core import timeutil
 from quota import db as _db
+from quota import dns_rules as _dns_rules
 from quota.engine import GATEWAY_MAC, EngineSnapshot, SnapshotHolder
 from quota.service import GB, QuotaService
 from quota.vendor import vendor_for
@@ -41,6 +45,26 @@ log = logging.getLogger("quota.api")
 WEB_DIR = Path(__file__).resolve().parent.parent / "web"
 COOKIE_NAME = "qmsession"
 SESSION_TTL_SEC = 60 * 60 * 24 * 7  # 7 days
+
+
+def _normalize_domains(raw_domains: set[str]) -> tuple[list[str], int]:
+    """Run quota.dns_rules.normalize_pattern over a whole domain set,
+    dropping anything unenforceable rather than failing the batch.
+
+    Pulled out to module level (not a route-local closure) so it can be
+    handed to ``asyncio.to_thread`` — a large preset/import (the
+    ads-tracking preset alone is 100k+ domains) is real CPU work worth
+    moving off the event loop, not just the network fetch that precedes it.
+    Returns (normalized_domains, skipped_count).
+    """
+    domains: list[str] = []
+    skipped = 0
+    for raw in raw_domains:
+        try:
+            domains.append(_dns_rules.normalize_pattern(raw))
+        except ValueError:
+            skipped += 1
+    return domains, skipped
 
 
 def _read_log_tail(path: str | Path | None, limit: int = 300) -> dict[str, Any]:
@@ -105,6 +129,7 @@ def create_app(
     topology_manager: object | None = None,
     shaping_sync: Optional[Callable[[], object]] = None,
     report_config: object | None = None,
+    dns_apply: Optional[Callable[[], object]] = None,
 ) -> FastAPI:
     app = FastAPI(title="Quota Manager", version=__version__,
                   docs_url="/api/docs", openapi_url="/api/openapi.json")
@@ -121,6 +146,18 @@ def create_app(
             return
         try:
             asyncio.create_task(shaping_sync())
+        except RuntimeError:  # no running event loop (should not happen in a route)
+            pass
+
+    def _schedule_dns_apply() -> None:
+        """Apply a domain-rule / DNS-server edit to dnsmasq right away (no
+        15 s tick wait). Fire-and-forget, same pattern as
+        ``_schedule_shaping_sync``; ``dns_apply`` is run.py's callback and is
+        a no-op when unset (tests / degraded boot)."""
+        if dns_apply is None:
+            return
+        try:
+            asyncio.create_task(dns_apply())
         except RuntimeError:  # no running event loop (should not happen in a route)
             pass
 
@@ -206,6 +243,8 @@ def create_app(
             # per-device internet speed caps (Mbps, 0 = unlimited)
             "limit_down_mbps": float(dev.limit_down_mbps or 0.0),
             "limit_up_mbps": float(dev.limit_up_mbps or 0.0),
+            # per-device upstream DNS-server override (empty = inherit)
+            "dns_server": dev.dns_server or "",
             "allowance_gb": allowance,
             "used_gb": used_gb,
             "live_up": live_c.up,
@@ -257,6 +296,8 @@ def create_app(
                 "limit_up_mbps": float(u.limit_up_mbps or 0.0),
                 # DNS-history retention override (days); None = global default
                 "history_days": u.history_days,
+                # per-user upstream DNS-server override (empty = inherit)
+                "dns_server": u.dns_server or "",
                 "allowance_gb": round(allowance, 3),
                 "used_gb": round(used_gb, 3),
                 "percent": round(used_gb / allowance * 100, 1) if allowance > 0 else 0.0,
@@ -548,11 +589,40 @@ def create_app(
         if did is None:
             for item, r in zip(recent, hist["recent"]):
                 item["device_id"] = r["device_id"]
+        # Filter-status annotation: for each domain actually seen, resolve
+        # what the LIVE dnsmasq config would do with it right now (block/
+        # allow/redirect/none) — see quota/dns_rules.resolve_domain_status,
+        # which mirrors dnsmasq's own longest-domain-match + scope
+        # precedence exactly, so this is never an approximation. A specific
+        # device also gets its owning user's scope considered (a user-level
+        # rule reaches it); the "all devices" aggregate only has global-scope
+        # rules to go on, since no single device context applies to it.
+        rules = await database.list_domain_rules(enabled_only=True)
+        status_user_id = dev.user_id if did is not None else None
+        top_domains = []
+        for t in hist["top_domains"]:
+            status, _rule = _dns_rules.resolve_domain_status(
+                t["domain"], rules, did, status_user_id)
+            top_domains.append({**t, "status": status})
+        owner_cache: dict[int, int | None] = {}  # device_id -> user_id, memoized
+        for item in recent:
+            # An aggregate row may belong to a DIFFERENT device than `did`
+            # (did is None here) — resolve against that row's own device/user.
+            row_did = item.get("device_id", did)
+            row_uid = status_user_id
+            if did is None and row_did is not None:
+                if row_did not in owner_cache:
+                    owner = await database.get_device(row_did)
+                    owner_cache[row_did] = owner.user_id if owner else None
+                row_uid = owner_cache[row_did]
+            status, _rule = _dns_rules.resolve_domain_status(
+                item["domain"], rules, row_did, row_uid)
+            item["status"] = status
         return {
             "device_id": "all" if did is None else did,
             "window_hours": window,
             "total_queries": hist["total"],
-            "top_domains": hist["top_domains"],
+            "top_domains": top_domains,
             "activity": [{"bucket_minute": a["minute"], "count": a["hits"]}
                          for a in hist["activity"]],
             "recent": recent,
@@ -807,6 +877,233 @@ def create_app(
         if result is None:
             raise HTTPException(404, "user not found")
         return result
+
+    @app.patch("/api/users/{user_id}/dns", dependencies=[Depends(_require_auth)])
+    async def set_user_dns(user_id: int, body: DnsServerUpdate) -> dict[str, Any]:
+        user = await database.get_user(user_id)
+        if user is None:
+            raise HTTPException(404, "user not found")
+        await database.update_user(user_id, dns_server=body.dns_server.strip())
+        await database.add_event(
+            f"DNS server for user '{user.name or user_id}' set to "
+            f"{body.dns_server.strip() or '(inherit default)'}", "info",
+            user_id=user_id)
+        _schedule_dns_apply()
+        return {"id": user_id, "dns_server": body.dns_server.strip()}
+
+    @app.patch("/api/devices/{device_id}/dns", dependencies=[Depends(_require_auth)])
+    async def set_device_dns(device_id: int, body: DnsServerUpdate) -> dict[str, Any]:
+        dev = await database.get_device(device_id)
+        if dev is None:
+            raise HTTPException(404, "device not found")
+        await database.update_device(device_id, dns_server=body.dns_server.strip())
+        await database.add_event(
+            f"DNS server for device '{dev.name or dev.mac}' set to "
+            f"{body.dns_server.strip() or '(inherit default)'}", "info",
+            device_id)
+        _schedule_dns_apply()
+        return {"id": device_id, "dns_server": body.dns_server.strip()}
+
+    # -- domain filtering (blacklist / allow-list / custom hosts) -----------
+
+    def _rule_view(rule: _db.DomainRule) -> dict[str, Any]:
+        return {
+            "id": rule.id, "scope": rule.scope, "scope_id": rule.scope_id,
+            "action": rule.action, "domain": rule.domain,
+            "target_ip": rule.target_ip, "enabled": rule.enabled,
+            "source": rule.source, "created_at": rule.created_at,
+        }
+
+    @app.get("/api/dns/rules", dependencies=[Depends(_require_auth)])
+    async def list_dns_rules(scope: Optional[str] = None,
+                             scope_id: Optional[int] = None) -> list[dict[str, Any]]:
+        rules = await database.list_domain_rules(scope, scope_id)
+        return [_rule_view(r) for r in rules]
+
+    @app.post("/api/dns/rules", status_code=201, dependencies=[Depends(_require_auth)])
+    async def create_dns_rule(body: DomainRuleCreate) -> dict[str, Any]:
+        if body.scope != "global" and body.scope_id is None:
+            raise HTTPException(400, "scope_id is required for a user/device rule")
+        if body.action == "redirect" and not body.target_ip:
+            raise HTTPException(400, "target_ip is required for a redirect rule")
+        try:
+            domain = _dns_rules.normalize_pattern(body.domain)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from None
+        if body.scope == "user" and await database.get_user(body.scope_id) is None:
+            raise HTTPException(404, "user not found")
+        if body.scope == "device" and await database.get_device(body.scope_id) is None:
+            raise HTTPException(404, "device not found")
+        rule = await database.create_domain_rule(
+            body.scope, body.action, domain, scope_id=body.scope_id,
+            target_ip=body.target_ip, enabled=body.enabled, source="manual")
+        await database.add_event(
+            f"DNS rule added: {body.action} {domain} ({body.scope})", "info")
+        _schedule_dns_apply()
+        return _rule_view(rule)
+
+    @app.patch("/api/dns/rules/{rule_id}", dependencies=[Depends(_require_auth)])
+    async def update_dns_rule(rule_id: int, body: DomainRuleUpdate) -> dict[str, Any]:
+        rule = await database.get_domain_rule(rule_id)
+        if rule is None:
+            raise HTTPException(404, "rule not found")
+        fields: dict[str, Any] = {}
+        if body.enabled is not None:
+            fields["enabled"] = body.enabled
+        if body.target_ip is not None:
+            fields["target_ip"] = body.target_ip
+        if fields:
+            await database.update_domain_rule(rule_id, **fields)
+        _schedule_dns_apply()
+        return {"id": rule_id, "updated": True}
+
+    @app.delete("/api/dns/rules/{rule_id}", dependencies=[Depends(_require_auth)])
+    async def delete_dns_rule(rule_id: int) -> dict[str, Any]:
+        rule = await database.get_domain_rule(rule_id)
+        if rule is None:
+            raise HTTPException(404, "rule not found")
+        await database.delete_domain_rule(rule_id)
+        await database.add_event(f"DNS rule removed: {rule.action} {rule.domain}", "info")
+        _schedule_dns_apply()
+        return {"id": rule_id, "deleted": True}
+
+    @app.post("/api/dns/rules/quick", status_code=201, dependencies=[Depends(_require_auth)])
+    async def quick_dns_rule(body: DnsQuickRule) -> dict[str, Any]:
+        """One-click block/allow for a domain a device has actually queried
+        (the History tab's per-domain buttons). Narrower than the general
+        rule-create endpoint on purpose: only ``global``/``device`` scope,
+        matching the two choices the History UI actually offers."""
+        if body.scope == "device":
+            if body.device_id is None:
+                raise HTTPException(400, "device_id is required for scope=device")
+            if await database.get_device(body.device_id) is None:
+                raise HTTPException(404, "device not found")
+        try:
+            domain = _dns_rules.normalize_pattern(body.domain)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from None
+        scope_id = body.device_id if body.scope == "device" else None
+        rule = await database.create_domain_rule(
+            body.scope, body.action, domain, scope_id=scope_id, source="manual")
+        await database.add_event(
+            f"DNS rule added from history: {body.action} {domain} "
+            f"({body.scope})", "info")
+        _schedule_dns_apply()
+        return _rule_view(rule)
+
+    @app.post("/api/dns/import", dependencies=[Depends(_require_auth)])
+    async def import_dns_rules(body: DnsImportRequest) -> dict[str, Any]:
+        """Paste raw hosts-format or AdBlock-Plus-format text -> domain_rules
+        rows, in ONE bulk insert (see database.create_domain_rules_bulk —
+        a per-row insert+commit loop is what made preset-enable freeze on a
+        large list; a pasted import can be just as large)."""
+        if body.scope != "global" and body.scope_id is None:
+            raise HTTPException(400, "scope_id is required for a user/device rule")
+        raw_domains = _dns_rules.compile_source_text(body.text, body.format)
+        # Parsing + per-domain normalization is pure CPU with no I/O, but a
+        # very large paste (tens of thousands of lines) is still enough work
+        # to be worth moving off the event loop, same reasoning as the
+        # preset-enable path below.
+        domains, skipped = await asyncio.to_thread(
+            _normalize_domains, raw_domains)
+        created = await database.create_domain_rules_bulk(
+            body.scope, body.action, domains, scope_id=body.scope_id,
+            source="import")
+        await database.add_event(
+            f"Imported {created} domain rule(s) ({body.action}, {skipped} skipped)",
+            "info")
+        _schedule_dns_apply()
+        return {"created": created, "skipped": skipped}
+
+    @app.get("/api/dns/presets", dependencies=[Depends(_require_auth)])
+    async def list_dns_presets() -> list[dict[str, Any]]:
+        states = {s["preset_id"]: s for s in await database.list_preset_states()}
+        out = []
+        for preset in _dns_rules.PRESETS.values():
+            state = states.get(preset.id, {})
+            out.append({
+                "id": preset.id, "name": preset.name,
+                "description": preset.description,
+                "enabled": bool(state.get("enabled", 0)),
+                "scope": state.get("scope", "global"),
+                "scope_id": state.get("scope_id"),
+                "domain_count": state.get("domain_count", 0),
+                "updated_at": state.get("updated_at", 0),
+            })
+        return out
+
+    @app.post("/api/dns/presets/{preset_id}/enable", dependencies=[Depends(_require_auth)])
+    async def enable_dns_preset(preset_id: str, body: DnsPresetEnable) -> dict[str, Any]:
+        preset = _dns_rules.PRESETS.get(preset_id)
+        if preset is None:
+            raise HTTPException(404, "unknown preset")
+        if body.scope != "global" and body.scope_id is None:
+            raise HTTPException(400, "scope_id is required for a user/device preset")
+        # Fetching runs in a thread — it's a blocking network call (urllib)
+        # and must never stall the event loop / WebSocket push.
+        try:
+            raw_domains = await asyncio.to_thread(_dns_rules.fetch_preset, preset)
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(502, f"failed to fetch preset sources: {exc}") from None
+        # Normalization of a 100k+ domain list (ads-tracking) is real CPU
+        # work — off the event loop too, so a large preset never stalls the
+        # WS push or another request while it enables.
+        domains, _skipped = await asyncio.to_thread(_normalize_domains, raw_domains)
+
+        # Scope-change leak fix: if this preset was already enabled at a
+        # DIFFERENT scope, its old rules are orphaned unless purged here —
+        # set_preset_state below only remembers the NEW scope, so the old
+        # scope's source_tag would otherwise never be reachable again.
+        prior = await database.get_preset_state(preset_id)
+        if prior and prior.get("enabled") and (
+                prior.get("scope") != body.scope
+                or prior.get("scope_id") != body.scope_id):
+            old_tag = (f"preset:{preset_id}:{prior['scope']}:"
+                      f"{prior.get('scope_id') or 0}")
+            removed = await database.delete_domain_rules_by_source(old_tag)
+            log.info("DNS preset %s moved scope (%s/%s -> %s/%s): purged "
+                    "%d rule(s) from the old scope", preset_id,
+                    prior.get("scope"), prior.get("scope_id"),
+                    body.scope, body.scope_id, removed)
+
+        source_tag = f"preset:{preset_id}:{body.scope}:{body.scope_id or 0}"
+        # Replace any previous rules from this exact preset+scope (a refresh
+        # re-enables cleanly instead of accumulating stale domains forever).
+        await database.delete_domain_rules_by_source(source_tag)
+        count = await database.create_domain_rules_bulk(
+            body.scope, "block", domains, scope_id=body.scope_id,
+            source=source_tag)
+        await database.set_preset_state(
+            preset_id, True, scope=body.scope, scope_id=body.scope_id,
+            domain_count=count)
+        await database.add_event(
+            f"DNS preset enabled: {preset.name} ({count} domains, {body.scope})",
+            "info")
+        _schedule_dns_apply()
+        return {"id": preset_id, "enabled": True, "domain_count": count}
+
+    @app.post("/api/dns/presets/{preset_id}/disable", dependencies=[Depends(_require_auth)])
+    async def disable_dns_preset(preset_id: str, body: DnsPresetEnable) -> dict[str, Any]:
+        if preset_id not in _dns_rules.PRESETS:
+            raise HTTPException(404, "unknown preset")
+        source_tag = f"preset:{preset_id}:{body.scope}:{body.scope_id or 0}"
+        removed = await database.delete_domain_rules_by_source(source_tag)
+        await database.set_preset_state(
+            preset_id, False, scope=body.scope, scope_id=body.scope_id,
+            domain_count=0)
+        await database.add_event(
+            f"DNS preset disabled: {preset_id} ({removed} rules removed)", "info")
+        _schedule_dns_apply()
+        return {"id": preset_id, "enabled": False, "removed": removed}
+
+    @app.post("/api/dns/apply", dependencies=[Depends(_require_auth)])
+    async def apply_dns_now() -> dict[str, Any]:
+        """Force an immediate dnsmasq regeneration + reload (normally
+        automatic after every rule/preset/DNS-server edit above)."""
+        if dns_apply is None:
+            return {"applied": False, "reason": "dns manager not wired"}
+        await dns_apply()
+        return {"applied": True}
 
     @app.get("/api/usage/{device_id}", dependencies=[Depends(_require_auth)])
     async def usage_series(device_id: int, since: str = "") -> list[dict[str, Any]]:

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import ipaddress
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 def _cap_field() -> Field:
@@ -154,6 +155,120 @@ class WanUpdate(BaseModel):
     pppoe_user: Optional[str] = None
     pppoe_password: Optional[str] = None
     wan_if: Optional[str] = None
+
+
+class DnsServerUpdate(BaseModel):
+    """Per-user or per-device upstream DNS-server override.
+
+    Rendered as a tag-restricted dnsmasq ``server=`` line (see
+    quota/dns_rules.py). Empty string clears the override (falls back to the
+    user's override, then the gateway's default upstreams). Must be a bare
+    IPv4/IPv6 address — this string is written directly into generated
+    dnsmasq config, so anything else (in particular embedded whitespace/
+    newlines) is rejected rather than risk a config-injection line.
+    """
+
+    dns_server: str = Field("", max_length=64)
+
+    @field_validator("dns_server")
+    @classmethod
+    def _validate_ip_or_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            return v
+        try:
+            ipaddress.ip_address(v)
+        except ValueError:
+            raise ValueError(
+                f"dns_server must be a bare IP address, got {v!r}") from None
+        return v
+
+
+class DomainRuleCreate(BaseModel):
+    """One domain-filtering rule. ``scope``/``scope_id`` together decide who
+    it applies to: ``global`` (scope_id ignored), ``user`` (scope_id = a
+    user id — fanned out to every device that user owns), or ``device``
+    (scope_id = a device id). ``domain`` accepts an optional leading
+    ``*.`` (stripped — dnsmasq's match already includes every subdomain);
+    any other ``*`` is rejected as unenforceable. ``target_ip`` is only used
+    when ``action == "redirect"`` and must be a bare IP — like
+    ``dns_server``, it is written directly into generated dnsmasq config.
+    """
+
+    scope: str = Field("global", pattern="^(global|user|device)$")
+    scope_id: Optional[int] = None
+    action: str = Field("block", pattern="^(block|allow|redirect)$")
+    domain: str = Field(..., min_length=1, max_length=253)
+    target_ip: Optional[str] = None
+    enabled: bool = True
+
+    @field_validator("target_ip")
+    @classmethod
+    def _validate_target_ip(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or not v.strip():
+            return None
+        v = v.strip()
+        try:
+            ipaddress.ip_address(v)
+        except ValueError:
+            raise ValueError(
+                f"target_ip must be a bare IP address, got {v!r}") from None
+        return v
+
+
+class DomainRuleUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    target_ip: Optional[str] = None
+
+    @field_validator("target_ip")
+    @classmethod
+    def _validate_target_ip(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or not v.strip():
+            return v  # None = "leave unchanged" for a PATCH; see api/app.py
+        v = v.strip()
+        try:
+            ipaddress.ip_address(v)
+        except ValueError:
+            raise ValueError(
+                f"target_ip must be a bare IP address, got {v!r}") from None
+        return v
+
+
+class DnsPresetEnable(BaseModel):
+    """Turn a built-in blocklist preset on/off for a scope (default: the
+    whole household). Enabling fetches + compiles the preset's source(s)
+    (or uses the curated inline list for presets with none) into
+    ``domain_rules`` rows tagged ``source='preset:<preset_id>:<scope>:
+    <scope_id>'``; disabling — or re-enabling at a DIFFERENT scope — removes
+    exactly those rows (see api/app.py's enable_dns_preset)."""
+
+    scope: str = Field("global", pattern="^(global|user|device)$")
+    scope_id: Optional[int] = None
+
+
+class DnsImportRequest(BaseModel):
+    """Paste raw hosts-format or AdBlock-Plus-format blocklist text and turn
+    it into domain_rules rows (source='import'). ``format`` picks the
+    parser; "auto" tries hosts-format first, then AdBlock-Plus."""
+
+    text: str = Field(..., min_length=1)
+    format: str = Field("auto", pattern="^(auto|hosts|adblock)$")
+    scope: str = Field("global", pattern="^(global|user|device)$")
+    scope_id: Optional[int] = None
+    action: str = Field("block", pattern="^(block|allow)$")
+
+
+class DnsQuickRule(BaseModel):
+    """One-click block/allow from the browsing-history view: pick a domain
+    a device has actually queried and file a rule for it without leaving
+    the History tab. ``scope`` is deliberately narrowed to just
+    ``global``/``device`` (not ``user``) — the two choices the History tab
+    actually offers ("this device only" / "everyone")."""
+
+    domain: str = Field(..., min_length=1, max_length=253)
+    action: str = Field(..., pattern="^(block|allow)$")
+    scope: str = Field(..., pattern="^(global|device)$")
+    device_id: Optional[int] = None
 
 
 class WanTest(BaseModel):

--- a/config.yaml
+++ b/config.yaml
@@ -133,3 +133,28 @@ history:
   enabled: true
   dnsmasq_log_file: /var/log/quota-dnsmasq.log
   retention_days: 7
+
+# Domain-level DNS filtering: per-user/per-device blacklists, allow-list
+# exceptions, custom host redirects, curated blocklist presets (ads/tracking,
+# social media, streaming, gambling), and per-user/per-device upstream
+# DNS-server overrides. Implemented as GENERATED dnsmasq config — no new
+# service is started, and this box already owns DHCP+DNS (see the dhcp:
+# block above). Rules/presets/DNS-server overrides themselves are edited in
+# the dashboard (stored in the DB, api/app.py's /api/dns/* routes); this
+# block only sets where the generated files live and whether to auto-reload.
+#   enabled: true              # master switch
+#   conf_dir: /etc/dnsmasq.d   # dnsmasq's conf-dir (Debian/Kali default)
+#   tags_file: quota-tags.conf     # per-device DHCP tag bindings
+#   rules_file: quota-domains.conf # domain rules + DNS-server overrides
+#   reload_dnsmasq: true       # restart dnsmasq when the generated files
+#                              # change (new address=/server= lines are only
+#                              # picked up on a restart, not a SIGHUP — costs
+#                              # clients a ~1s DNS blip per rule change)
+#   preset_cache_dir: data/dns_presets
+dns_filter:
+  enabled: true
+  conf_dir: /etc/dnsmasq.d
+  tags_file: quota-tags.conf
+  rules_file: quota-domains.conf
+  reload_dnsmasq: true
+  preset_cache_dir: data/dns_presets

--- a/core/config.py
+++ b/core/config.py
@@ -189,6 +189,45 @@ class HistoryConfig:
 
 
 @dataclass
+class DnsFilterConfig:
+    """Domain-level filtering: per-user/per-device blacklists, allow-list
+    exceptions, custom host redirects, curated blocklist presets, and
+    per-user/per-device upstream DNS-server overrides.
+
+    Implemented entirely as GENERATED dnsmasq configuration — this box
+    already owns DHCP + DNS (see ``DhcpConfig``), so no new service is
+    started and the nftables/tc packet paths are untouched. See
+    ``quota/dns_rules.py`` for the renderer/parsers and
+    ``quota.db``'s ``domain_rules`` / ``dns_presets`` tables for storage.
+    """
+
+    enabled: bool = True
+    #: Directory dnsmasq scans for ``*.conf`` (Debian/Kali ship
+    #: ``conf-dir=/etc/dnsmasq.d`` in ``/etc/dnsmasq.conf`` by default — the
+    #: setup script does not need to add this on a stock install).
+    conf_dir: str = "/etc/dnsmasq.d"
+    #: Filenames written INSIDE conf_dir. Kept separate from
+    #: ``quota-gateway.conf`` (the DHCP/DNS base config written by the setup
+    #: script) and ``quota-dnslog.conf`` (the browsing-history feature's own
+    #: fragment) so a domain-rule edit never touches either, and kept
+    #: separate from EACH OTHER so tags (rarely change) and rules (change
+    #: often) can be diffed/rewritten independently.
+    tags_file: str = "quota-tags.conf"
+    rules_file: str = "quota-domains.conf"
+    #: dnsmasq only picks up NEW ``address=``/``server=``/``dhcp-host=``
+    #: lines on a restart — SIGHUP only re-reads ``/etc/hosts`` and
+    #: lease-adjacent files. True (default) restarts dnsmasq whenever the
+    #: generated files actually changed (~1 s DNS blip for clients); False
+    #: writes the files but skips the reload, for an admin who wants to
+    #: batch several edits before a manual ``systemctl restart dnsmasq``.
+    reload_dnsmasq: bool = True
+    #: Where fetched blocklist presets are cached on disk (raw text, so a
+    #: restart does not need to re-fetch before an already-enabled preset's
+    #: rules can be rebuilt). Relative paths resolve under the project root.
+    preset_cache_dir: str = "data/dns_presets"
+
+
+@dataclass
 class Config:
     db_path: str = "data/quota.db"
     log_file: str = "logs/quota.log"
@@ -200,6 +239,7 @@ class Config:
     shaping: ShapingConfig = field(default_factory=ShapingConfig)
     report: ReportConfig = field(default_factory=ReportConfig)
     history: HistoryConfig = field(default_factory=HistoryConfig)
+    dns_filter: DnsFilterConfig = field(default_factory=DnsFilterConfig)
     timezone: str = ""  # empty => system local timezone
 
 

--- a/quota/db.py
+++ b/quota/db.py
@@ -23,10 +23,13 @@ the API/service layer.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
+
+log = logging.getLogger("quota.db")
 
 import aiosqlite
 
@@ -42,6 +45,17 @@ QUOTA_AUTO = "auto"
 BLOCK_OK = "ok"          # allowed, within quota
 BLOCK_QUOTA = "quota"    # exceeded monthly allowance
 BLOCK_ADMIN = "admin_off"  # manually switched off by admin
+
+# Domain-rule scope + action enums (see quota/dns_rules.py for the same
+# constants used by the dnsmasq renderer — kept independent so db.py never
+# has to import the renderer module).
+DNS_SCOPE_GLOBAL = "global"
+DNS_SCOPE_USER = "user"
+DNS_SCOPE_DEVICE = "device"
+
+DNS_ACTION_BLOCK = "block"
+DNS_ACTION_ALLOW = "allow"
+DNS_ACTION_REDIRECT = "redirect"
 
 
 # ---------------------------------------------------------------------------
@@ -70,6 +84,11 @@ class Device:
     #: tc shaper (quota/shaping.py).
     limit_down_mbps: float = 0.0
     limit_up_mbps: float = 0.0
+    #: Per-device upstream DNS server override (empty = inherit the user's
+    #: override, or the gateway's default upstreams if neither is set).
+    #: Rendered as a tag-restricted dnsmasq `server=` line — see
+    #: quota/dns_rules.py.
+    dns_server: str = ""
 
     @property
     def is_blocked(self) -> bool:
@@ -109,10 +128,34 @@ class User:
     #: Per-user DNS-history retention in days; None = the global
     #: ``history.retention_days`` default applies.
     history_days: Optional[int] = None
+    #: Per-user upstream DNS server override, inherited by every device of
+    #: this user that has no override of its own (empty = no override).
+    dns_server: str = ""
 
     @property
     def is_admin_blocked(self) -> bool:
         return self.block_state == BLOCK_ADMIN
+
+
+@dataclass
+class DomainRule:
+    """One domain-filtering rule: block/allow/redirect a domain (+ every
+    subdomain — dnsmasq's match already covers those), scoped globally, to a
+    user (fanned out to all their devices at render time), or to a single
+    device. See quota/dns_rules.py for how this becomes dnsmasq config."""
+
+    id: int
+    scope: str = DNS_SCOPE_GLOBAL          # 'global' | 'user' | 'device'
+    scope_id: Optional[int] = None         # user_id / device_id; None for global
+    action: str = DNS_ACTION_BLOCK         # 'block' | 'allow' | 'redirect'
+    domain: str = ""                       # normalized, no leading "*."
+    target_ip: Optional[str] = None        # only meaningful for 'redirect'
+    enabled: bool = True
+    #: 'manual' (admin-entered) | 'preset:<preset_id>:<scope>:<scope_id>'
+    #: (from an enabled blocklist preset) | 'import' (pasted hosts/
+    #: AdBlock-Plus text).
+    source: str = "manual"
+    created_at: float = 0.0
 
 
 @dataclass
@@ -144,7 +187,8 @@ CREATE TABLE IF NOT EXISTS devices (
     created_at       REAL NOT NULL,
     topup_gb         REAL NOT NULL DEFAULT 0,
     limit_down_mbps  REAL NOT NULL DEFAULT 0,
-    limit_up_mbps    REAL NOT NULL DEFAULT 0
+    limit_up_mbps    REAL NOT NULL DEFAULT 0,
+    dns_server       TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS leases (
@@ -214,12 +258,57 @@ CREATE TABLE IF NOT EXISTS users (
     notified_50      INTEGER NOT NULL DEFAULT 0,
     notified_75      INTEGER NOT NULL DEFAULT 0,
     notified_100     INTEGER NOT NULL DEFAULT 0,
-    history_days     INTEGER              -- NULL = global history.retention_days
+    history_days     INTEGER,             -- NULL = global history.retention_days
+    dns_server       TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS suppressed_macs (
     mac        TEXT PRIMARY KEY,
     created_at REAL NOT NULL
+);
+
+-- Domain-level DNS filtering (quota/dns_rules.py renders these into
+-- generated dnsmasq config). scope_id is a user_id or device_id depending on
+-- `scope`, and NULL for scope='global'.
+--
+-- scope_key exists ONLY so the UNIQUE constraint below actually behaves like
+-- an upsert key: SQLite treats every NULL as DISTINCT from every other NULL,
+-- so a naive UNIQUE(scope, scope_id, domain, action) never collides for two
+-- 'global' rows (scope_id is NULL on both) — re-submitting the same global
+-- rule silently INSERTs a duplicate instead of updating the existing one.
+-- scope_key is a NOT NULL stand-in (COALESCE(scope_id, 0)) so two 'global'
+-- rows for the same domain/action DO collide and the upsert in
+-- create_domain_rule fires correctly. 0 is never a real user/device id
+-- (AUTOINCREMENT starts at 1), so it cannot collide with a genuine scope_id.
+CREATE TABLE IF NOT EXISTS domain_rules (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    scope      TEXT NOT NULL DEFAULT 'global',
+    scope_id   INTEGER,
+    scope_key  INTEGER GENERATED ALWAYS AS (COALESCE(scope_id, 0)) STORED,
+    action     TEXT NOT NULL DEFAULT 'block',
+    domain     TEXT NOT NULL,
+    target_ip  TEXT,
+    enabled    INTEGER NOT NULL DEFAULT 1,
+    source     TEXT NOT NULL DEFAULT 'manual',
+    created_at REAL NOT NULL,
+    UNIQUE(scope, scope_key, domain, action)
+);
+
+-- One row per built-in blocklist preset (quota/dns_rules.py:PRESETS) that
+-- has ever been enabled somewhere, so the dashboard can show its state
+-- (enabled/disabled, how many domains, when it was last refreshed) without
+-- re-fetching the source. Enabling a preset also inserts domain_rules rows
+-- (source='preset:<preset_id>:<scope>:<scope_id>') for its compiled domain
+-- list; disabling it, or re-enabling it at a DIFFERENT scope, deletes those
+-- rows again (see api/app.py's enable_dns_preset — the old-scope purge is
+-- what prevents an orphaned rule set from a scope change).
+CREATE TABLE IF NOT EXISTS dns_presets (
+    preset_id    TEXT PRIMARY KEY,
+    enabled      INTEGER NOT NULL DEFAULT 0,
+    scope        TEXT NOT NULL DEFAULT 'global',
+    scope_id     INTEGER,
+    domain_count INTEGER NOT NULL DEFAULT 0,
+    updated_at   REAL NOT NULL DEFAULT 0
 );
 """
 
@@ -321,8 +410,80 @@ class Database:
             await self._conn.commit()
         except Exception:  # noqa: BLE001  (duplicate column on existing DBs)
             pass
+        # DNS filtering: per-user/per-device upstream DNS-server override
+        # column. ALTER no-ops when already present (fresh SCHEMA includes
+        # it); domain_rules/dns_presets are brand-new tables created by the
+        # executescript above, no ALTER needed for those, but a domain_rules
+        # table created by a PRE-FIX build (missing scope_key) does need a
+        # one-time rebuild — see _migrate_domain_rules_scope_key.
+        for table in ("devices", "users"):
+            try:
+                await self._conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN dns_server "
+                    "TEXT NOT NULL DEFAULT ''")
+                await self._conn.commit()
+            except Exception:  # noqa: BLE001  (duplicate column on existing DBs)
+                pass
+        await self._migrate_domain_rules_scope_key()
         await self._backfill_users()
         await self._seed_gateway()
+        await self._conn.commit()
+
+    async def _migrate_domain_rules_scope_key(self) -> None:
+        """One-time repair for a ``domain_rules`` table created by a
+        pre-fix build of the DNS-filtering feature.
+
+        The original ``UNIQUE(scope, scope_id, domain, action)`` constraint
+        never actually deduplicated global-scope rows: SQLite treats every
+        NULL as distinct from every other NULL, so ``scope_id IS NULL``
+        never collided and re-submitting the same global rule silently
+        inserted a duplicate row instead of updating the existing one. The
+        fix adds a NOT NULL ``scope_key`` (``COALESCE(scope_id, 0)``) and
+        uniques on that instead (see the ``domain_rules`` table comment in
+        SCHEMA). A brand-new DB already gets the fixed table from
+        ``executescript`` above, so this is a no-op for it; only a DB that
+        already has the OLD shape gets rebuilt here, collapsing any
+        duplicates the old constraint let through (keeping the newest row
+        per scope/scope_id/domain/action).
+        """
+        row = await self._fetch_one(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='domain_rules'")
+        if row is None:
+            return  # nothing to migrate yet — SCHEMA creates the fixed table
+        cols = await self.conn.execute_fetchall("PRAGMA table_info(domain_rules)")
+        if any(c["name"] == "scope_key" for c in cols):
+            return  # already the fixed shape
+        log.warning("domain_rules predates the scope_key fix — rebuilding "
+                   "the table and dropping any duplicate global rules the "
+                   "old NULL-scope upsert bug let through")
+        await self._conn.executescript("""
+            ALTER TABLE domain_rules RENAME TO domain_rules_old;
+            CREATE TABLE domain_rules (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                scope      TEXT NOT NULL DEFAULT 'global',
+                scope_id   INTEGER,
+                scope_key  INTEGER GENERATED ALWAYS AS (COALESCE(scope_id, 0)) STORED,
+                action     TEXT NOT NULL DEFAULT 'block',
+                domain     TEXT NOT NULL,
+                target_ip  TEXT,
+                enabled    INTEGER NOT NULL DEFAULT 1,
+                source     TEXT NOT NULL DEFAULT 'manual',
+                created_at REAL NOT NULL,
+                UNIQUE(scope, scope_key, domain, action)
+            );
+        """)
+        await self._conn.execute("""
+            INSERT INTO domain_rules
+                (scope, scope_id, action, domain, target_ip, enabled, source, created_at)
+            SELECT scope, scope_id, action, domain, target_ip, enabled, source, created_at
+            FROM domain_rules_old
+            WHERE id IN (
+                SELECT MAX(id) FROM domain_rules_old
+                GROUP BY scope, COALESCE(scope_id, 0), domain, action
+            )
+        """)
+        await self._conn.execute("DROP TABLE domain_rules_old")
         await self._conn.commit()
 
     async def _backfill_users(self) -> None:
@@ -438,7 +599,8 @@ class Database:
 
     async def update_device(self, device_id: int, **fields: Any) -> Device | None:
         allowed = {"name", "quota_mode", "fixed_gb", "block_state",
-                   "user_id", "bypass", "limit_down_mbps", "limit_up_mbps"}
+                   "user_id", "bypass", "limit_down_mbps", "limit_up_mbps",
+                   "dns_server"}
         sets, args = [], []
         for key, value in fields.items():
             if key in allowed:
@@ -472,6 +634,9 @@ class Database:
         # rows are TTL-bounded by the quota period instead).
         await self.conn.execute(
             "DELETE FROM dns_history WHERE device_id=?", (device_id,))
+        # Device-scoped domain rules are meaningless once the device is gone
+        # (their dnsmasq tag would never be applied to anything again).
+        await self.delete_domain_rules_by_scope(DNS_SCOPE_DEVICE, device_id)
         await self.conn.commit()
 
     async def set_device_state(self, device_id: int, state: str) -> None:
@@ -551,7 +716,7 @@ class Database:
         allowed = {"name", "quota_mode", "fixed_gb", "block_state",
                    "limit_down_mbps", "limit_up_mbps",
                    "notified_50", "notified_75", "notified_100",
-                   "history_days"}
+                   "history_days", "dns_server"}
         sets, args = [], []
         for key, value in fields.items():
             if key in allowed:
@@ -585,8 +750,10 @@ class Database:
             await self.conn.execute(
                 "DELETE FROM usage_daily WHERE device_id=?", (r["id"],))
             await self.conn.execute("DELETE FROM devices WHERE id=?", (r["id"],))
+            await self.delete_domain_rules_by_scope(DNS_SCOPE_DEVICE, r["id"])
         await self.conn.execute("DELETE FROM users WHERE id=?", (user_id,))
         await self.conn.commit()
+        await self.delete_domain_rules_by_scope(DNS_SCOPE_USER, user_id)
         return len(rows)
 
     async def add_topup_user(self, user_id: int, extra_gb: float) -> None:
@@ -950,6 +1117,164 @@ class Database:
             "SELECT * FROM events ORDER BY ts DESC LIMIT ?", (limit,))
         return [dict(r) for r in rows]
 
+    # -- domain rules (DNS filtering) ----------------------------------------
+
+    async def create_domain_rule(self, scope: str, action: str, domain: str,
+                                 scope_id: int | None = None,
+                                 target_ip: str | None = None,
+                                 enabled: bool = True,
+                                 source: str = "manual") -> DomainRule:
+        """Insert (or update, if the same scope/scope_id/domain/action
+        combination already exists) one domain rule. The upsert targets
+        ``(scope, scope_key, domain, action)`` — NOT ``scope_id`` directly —
+        because SQLite treats every NULL as distinct, and scope_id is NULL
+        for every global rule; see the ``domain_rules`` table comment in
+        SCHEMA and ``_migrate_domain_rules_scope_key``."""
+        now = time.time()
+        await self.conn.execute(
+            """INSERT INTO domain_rules
+                 (scope, scope_id, action, domain, target_ip, enabled, source, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(scope, scope_key, domain, action) DO UPDATE SET
+                 target_ip=excluded.target_ip, enabled=excluded.enabled,
+                 source=excluded.source""",
+            (scope, scope_id, action, domain, target_ip, int(enabled),
+             source, now))
+        await self.conn.commit()
+        row = await self._fetch_one(
+            "SELECT * FROM domain_rules WHERE scope=? AND scope_id IS ? "
+            "AND domain=? AND action=?", (scope, scope_id, domain, action))
+        return _row_to_domain_rule(row)  # type: ignore[arg-type]
+
+    async def create_domain_rules_bulk(
+            self, scope: str, action: str, domains: list[str],
+            scope_id: int | None = None, source: str = "manual") -> int:
+        """Insert many domain rules in ONE transaction via ``executemany``.
+
+        Enabling a preset can mean 100k+ domains (e.g. the ads-tracking
+        list); doing an individual INSERT + commit per row in a Python loop
+        freezes SQLite for minutes and blocks the event loop for the whole
+        request. This does one ``executemany`` + one commit instead — same
+        shape as ``batch_add_dns_history``. Returns the number of domains
+        submitted (duplicates upsert in place, same as
+        :meth:`create_domain_rule`, so the count is submissions, not
+        necessarily new rows).
+        """
+        if not domains:
+            return 0
+        now = time.time()
+        rows = [(scope, scope_id, action, d, None, 1, source, now)
+               for d in domains]
+        await self.conn.executemany(
+            """INSERT INTO domain_rules
+                 (scope, scope_id, action, domain, target_ip, enabled, source, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(scope, scope_key, domain, action) DO UPDATE SET
+                 enabled=excluded.enabled, source=excluded.source""",
+            rows)
+        await self.conn.commit()
+        return len(rows)
+
+    async def get_domain_rule(self, rule_id: int) -> DomainRule | None:
+        row = await self._fetch_one(
+            "SELECT * FROM domain_rules WHERE id=?", (rule_id,))
+        return _row_to_domain_rule(row) if row else None
+
+    async def list_domain_rules(self, scope: str | None = None,
+                                scope_id: int | None = None,
+                                enabled_only: bool = False) -> list[DomainRule]:
+        """List rules, optionally filtered to one scope (and scope_id).
+        With no filter, returns every rule at every scope — what the
+        renderer (quota/dns_rules.py) needs to build the full config."""
+        sql = "SELECT * FROM domain_rules WHERE 1=1"
+        args: list[Any] = []
+        if scope is not None:
+            sql += " AND scope=?"
+            args.append(scope)
+            if scope_id is not None:
+                sql += " AND scope_id=?"
+                args.append(scope_id)
+        if enabled_only:
+            sql += " AND enabled=1"
+        sql += " ORDER BY id"
+        rows = await self.conn.execute_fetchall(sql, args)
+        return [_row_to_domain_rule(r) for r in rows]
+
+    async def update_domain_rule(self, rule_id: int, **fields: Any) -> DomainRule | None:
+        allowed = {"enabled", "target_ip", "domain", "action"}
+        sets, args = [], []
+        for key, value in fields.items():
+            if key in allowed:
+                sets.append(f"{key}=?")
+                args.append(int(value) if key == "enabled" else value)
+        if not sets:
+            return await self.get_domain_rule(rule_id)
+        args.append(rule_id)
+        await self.conn.execute(
+            f"UPDATE domain_rules SET {', '.join(sets)} WHERE id=?", args)
+        await self.conn.commit()
+        return await self.get_domain_rule(rule_id)
+
+    async def delete_domain_rule(self, rule_id: int) -> None:
+        await self.conn.execute("DELETE FROM domain_rules WHERE id=?", (rule_id,))
+        await self.conn.commit()
+
+    async def delete_domain_rules_by_source(self, source: str) -> int:
+        """Delete every rule with an exact ``source`` match (used to remove
+        a disabled preset's generated rules, or purge a preset's OLD
+        scope's rules when it is re-enabled somewhere else — see
+        api/app.py's enable_dns_preset). Returns the count removed."""
+        rows = await self.conn.execute_fetchall(
+            "SELECT id FROM domain_rules WHERE source=?", (source,))
+        await self.conn.execute(
+            "DELETE FROM domain_rules WHERE source=?", (source,))
+        await self.conn.commit()
+        return len(rows)
+
+    async def delete_domain_rules_by_scope(self, scope: str, scope_id: int | None) -> int:
+        """Delete every rule at one scope (used when a user/device is
+        deleted, so their per-scope rules don't linger orphaned)."""
+        rows = await self.conn.execute_fetchall(
+            "SELECT id FROM domain_rules WHERE scope=? AND scope_id IS ?",
+            (scope, scope_id))
+        await self.conn.execute(
+            "DELETE FROM domain_rules WHERE scope=? AND scope_id IS ?",
+            (scope, scope_id))
+        await self.conn.commit()
+        return len(rows)
+
+    # -- DNS blocklist presets ------------------------------------------------
+
+    async def get_preset_state(self, preset_id: str) -> dict[str, Any] | None:
+        row = await self._fetch_one(
+            "SELECT * FROM dns_presets WHERE preset_id=?", (preset_id,))
+        return dict(row) if row else None
+
+    async def list_preset_states(self) -> list[dict[str, Any]]:
+        rows = await self.conn.execute_fetchall(
+            "SELECT * FROM dns_presets ORDER BY preset_id")
+        return [dict(r) for r in rows]
+
+    async def set_preset_state(self, preset_id: str, enabled: bool,
+                               scope: str = DNS_SCOPE_GLOBAL,
+                               scope_id: int | None = None,
+                               domain_count: int = 0) -> None:
+        await self.conn.execute(
+            """INSERT INTO dns_presets (preset_id, enabled, scope, scope_id,
+                 domain_count, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)
+               ON CONFLICT(preset_id) DO UPDATE SET
+                 enabled=excluded.enabled, scope=excluded.scope,
+                 scope_id=excluded.scope_id, domain_count=excluded.domain_count,
+                 updated_at=excluded.updated_at""",
+            (preset_id, int(enabled), scope, scope_id, domain_count, time.time()))
+        await self.conn.commit()
+
+    async def delete_preset_state(self, preset_id: str) -> None:
+        await self.conn.execute(
+            "DELETE FROM dns_presets WHERE preset_id=?", (preset_id,))
+        await self.conn.commit()
+
 
 def _row_to_device(row: Any) -> Device:
     return Device(
@@ -965,6 +1290,7 @@ def _row_to_device(row: Any) -> Device:
         bypass=bool(row["bypass"]),
         limit_down_mbps=float(row["limit_down_mbps"] or 0.0),
         limit_up_mbps=float(row["limit_up_mbps"] or 0.0),
+        dns_server=row["dns_server"] or "",
     )
 
 
@@ -985,4 +1311,19 @@ def _row_to_user(row: Any) -> User:
         notified_75=bool(row["notified_75"]),
         notified_100=bool(row["notified_100"]),
         history_days=row["history_days"],
+        dns_server=row["dns_server"] or "",
+    )
+
+
+def _row_to_domain_rule(row: Any) -> DomainRule:
+    return DomainRule(
+        id=row["id"],
+        scope=row["scope"],
+        scope_id=row["scope_id"],
+        action=row["action"],
+        domain=row["domain"],
+        target_ip=row["target_ip"],
+        enabled=bool(row["enabled"]),
+        source=row["source"],
+        created_at=row["created_at"],
     )

--- a/quota/dns_rules.py
+++ b/quota/dns_rules.py
@@ -1,0 +1,539 @@
+"""Domain-level DNS filtering: blacklists, allow-list exceptions, custom host
+redirects, curated blocklist presets, and per-user/per-device upstream
+DNS-server overrides.
+
+Why this rides on dnsmasq instead of adding a new component
+-------------------------------------------------------------
+dnsmasq already owns DHCP + DNS on the gateway (see ``quota/db.py``'s module
+docstring and ``scripts/setup_gateway_kali.sh``). It already natively
+supports everything this feature needs:
+
+- ``address=/domain/target`` blackholes or redirects a domain AND every
+  subdomain of it — that IS the "wildcard" behaviour most people mean by
+  domain blocking; dnsmasq has no syntax for a glob in the MIDDLE of a
+  label, so a pattern like ``*.ads.*.example.com`` cannot be expressed here
+  (see :func:`normalize_pattern`, which rejects it rather than silently
+  accepting something that would never actually block anything).
+- ``server=upstream$tag`` sends one client's queries to a specific resolver
+  — the per-client DNS-server feature, for free.
+- DHCP tags (``dhcp-host=mac,set:tag``) are already how the box could bind a
+  MAC to DHCP options; they double as the "is this rule for THIS device"
+  selector, so nothing about the nftables (packet accounting/blocking) or tc
+  (speed shaping) subsystems changes.
+
+This module never touches nftables or tc. It only renders two extra files
+inside dnsmasq's already-active ``conf-dir`` (``/etc/dnsmasq.d`` by default)
+and restarts the dnsmasq unit when they actually change. A restart — not a
+SIGHUP — is required for dnsmasq to notice new ``address=``/``server=``/
+``dhcp-host=`` lines, which costs every client a brief (roughly one second)
+DNS blip on a rule change; see ``DnsRuleManager.apply``.
+
+Known, honest limitation: this is DNS-layer filtering. A client using
+DNS-over-HTTPS/TLS to a resolver outside the box (Android Private DNS,
+browser "secure DNS", etc.) or one that hardcodes a destination IP bypasses
+it entirely, the same way it already bypasses the box's regular DNS. Nothing
+here changes that; it is called out so it is not sold as airtight.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+log = logging.getLogger("quota.dns_rules")
+
+SCOPE_GLOBAL = "global"
+SCOPE_USER = "user"
+SCOPE_DEVICE = "device"
+
+ACTION_BLOCK = "block"
+ACTION_ALLOW = "allow"
+ACTION_REDIRECT = "redirect"
+
+_SCOPE_ORDER = {SCOPE_GLOBAL: 0, SCOPE_USER: 1, SCOPE_DEVICE: 2}
+
+
+# ---------------------------------------------------------------------------
+# Built-in presets — curated, ready-to-use blocklists
+# ---------------------------------------------------------------------------
+# Sources are HOSTS-format ("0.0.0.0 domain" / "127.0.0.1 domain") or
+# AdBlock-Plus-format ("||domain^") text; both are reduced to a flat domain
+# set by compile_source_text. Only network-address-shaped ABP rules survive
+# the conversion — element-hiding/path/regex rules have no DNS-layer
+# equivalent and are dropped (see parse_adblock_plus).
+
+@dataclass
+class Preset:
+    id: str
+    name: str
+    description: str
+    urls: list[str] = field(default_factory=list)
+    format: str = "auto"  # "hosts" | "adblock" | "auto" (sniff per source)
+
+
+PRESETS: dict[str, Preset] = {}
+
+
+def _register(p: Preset) -> None:
+    PRESETS[p.id] = p
+
+
+_register(Preset(
+    id="ads-tracking",
+    name="Ads & tracking",
+    description="General-purpose ads + tracking hosts blocklist (StevenBlack/hosts).",
+    urls=["https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"],
+    format="hosts",
+))
+_register(Preset(
+    id="social-media",
+    name="Social media",
+    description=("Facebook/Instagram/TikTok/Twitter/Discord and friends "
+                 "(cyb3rko/social-media-hosts-blocklists)."),
+    urls=[
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/facebookhosts.txt",
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/instagramhosts.txt",
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/tiktokhosts.txt",
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/twitterhosts.txt",
+        "https://raw.githubusercontent.com/cyb3rko/social-media-hosts-blocklists/main/discordhosts.txt",
+    ],
+    format="hosts",
+))
+_register(Preset(
+    id="streaming",
+    name="Streaming & video",
+    description=("Common video-streaming platforms (Netflix, YouTube, Twitch, "
+                 "Prime/Disney+/Hulu/HBO Max, Spotify) — curated inline, see "
+                 "STREAMING_DOMAINS below (no single well-maintained upstream "
+                 "list exists for this category)."),
+    urls=[],
+    format="hosts",
+))
+_register(Preset(
+    id="gambling",
+    name="Gambling",
+    description="Online gambling / betting sites (StevenBlack/hosts alternates).",
+    urls=["https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/gambling-only/hosts"],
+    format="hosts",
+))
+
+#: Curated inline list for the "streaming" preset — reused whenever a preset
+#: has no ``urls`` (see :func:`fetch_preset`).
+STREAMING_DOMAINS: set[str] = {
+    "netflix.com", "nflxvideo.net", "nflximg.net", "nflxso.net", "nflxext.com",
+    "youtube.com", "googlevideo.com", "ytimg.com", "youtu.be",
+    "twitch.tv", "ttvnw.net", "jtvnw.net",
+    "primevideo.com", "amazonvideo.com",
+    "disneyplus.com", "dssott.com",
+    "hulu.com", "hbomax.com", "max.com",
+    "spotify.com", "scdn.co",
+}
+
+
+# ---------------------------------------------------------------------------
+# Parsing: hosts-format and AdBlock-Plus-format -> a flat domain set
+# ---------------------------------------------------------------------------
+
+_HOSTS_LINE_RE = re.compile(
+    r"^\s*(?:0\.0\.0\.0|127\.0\.0\.1|::1)\s+([A-Za-z0-9.\-_]+)")
+_ABP_DOMAIN_RE = re.compile(r"^\|\|([A-Za-z0-9.\-_]+)\^")
+_HOSTS_SKIP = {
+    "localhost", "localhost.localdomain", "local", "broadcasthost",
+    "ip6-localhost", "ip6-loopback", "ip6-localnet", "ip6-mcastprefix",
+    "ip6-allnodes", "ip6-allrouters", "ip6-allhosts",
+}
+
+
+def parse_hosts_format(text: str) -> set[str]:
+    """Extract blocked domains from an ``/etc/hosts``-style blocklist.
+
+    Recognises ``0.0.0.0 domain`` / ``127.0.0.1 domain`` / ``::1 domain``
+    lines. Comments (``#``) and blank lines are ignored, and the handful of
+    loopback aliases every hosts file carries are skipped so they never end
+    up as a generated dnsmasq blackhole.
+    """
+    out: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        m = _HOSTS_LINE_RE.match(line)
+        if not m:
+            continue
+        domain = m.group(1).lower().strip(".")
+        if domain and domain not in _HOSTS_SKIP:
+            out.add(domain)
+    return out
+
+
+def parse_adblock_plus(text: str) -> set[str]:
+    """Extract the network-address-shaped rules from an AdBlock-Plus list.
+
+    Only ``||domain^`` (optionally followed by ``$options``) rules translate
+    to DNS-layer blocking. Element-hiding (``##``/``#@#``), path/regex rules,
+    and exception rules (``@@``) have no DNS-layer equivalent and are
+    dropped — this recovers a subset of what the list author intended, which
+    is the honest ceiling of what a DNS blocker can enforce from an ABP list.
+    """
+    out: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(("!", "[")):
+            continue
+        if line.startswith("@@"):
+            continue  # exception rule — never something to BLOCK
+        m = _ABP_DOMAIN_RE.match(line)
+        if not m:
+            continue
+        domain = m.group(1).lower().strip(".")
+        if domain:
+            out.add(domain)
+    return out
+
+
+def compile_source_text(text: str, fmt: str = "auto") -> set[str]:
+    """Parse one fetched/pasted blocklist, sniffing the format if needed."""
+    if fmt == "hosts":
+        return parse_hosts_format(text)
+    if fmt == "adblock":
+        return parse_adblock_plus(text)
+    domains = parse_hosts_format(text)
+    if domains:
+        return domains
+    return parse_adblock_plus(text)
+
+
+_DOMAIN_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?"
+                        r"(\.[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?)+$")
+
+
+def normalize_pattern(pattern: str) -> str:
+    """Normalize a user-entered domain pattern to what dnsmasq can enforce.
+
+    dnsmasq's ``address=/domain/`` match already covers the domain AND every
+    subdomain of it — that IS the "wildcard" support dnsmasq has. A leading
+    ``*.`` is therefore just stripped (dnsmasq cannot narrow a match to
+    "subdomains only, not the apex" — there is no syntax for that). Any
+    OTHER ``*`` (mid-label, e.g. ``*.ads.*.example.com``) is rejected rather
+    than silently accepted and never actually blocking anything.
+    """
+    p = pattern.strip().lower().rstrip(".")
+    if p.startswith("*."):
+        p = p[2:]
+    if not p or "*" in p or not _DOMAIN_RE.match(p):
+        raise ValueError(
+            f"unsupported domain pattern {pattern!r} — dnsmasq can only "
+            "match a plain domain (the match already includes every "
+            "subdomain); mid-label wildcards are not enforceable at the "
+            "DNS layer")
+    return p
+
+
+def fetch_url(url: str, timeout: float = 20.0) -> str:
+    """Best-effort fetch of a preset source. Raises on failure — the caller
+    decides whether that should keep a previously cached list."""
+    req = urllib.request.Request(url, headers={"User-Agent": "QuotaManager"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def fetch_preset(preset: Preset) -> set[str]:
+    """Fetch + parse every source URL of a preset into one domain set.
+
+    A preset with no ``urls`` (currently only "streaming") uses its curated
+    inline list instead. One failing source is logged and skipped rather
+    than failing the whole preset.
+    """
+    if not preset.urls:
+        if preset.id == "streaming":
+            return set(STREAMING_DOMAINS)
+        return set()
+    domains: set[str] = set()
+    for url in preset.urls:
+        try:
+            text = fetch_url(url)
+        except Exception:  # noqa: BLE001 — one bad source must not kill the rest
+            log.warning("failed to fetch preset source %s", url, exc_info=True)
+            continue
+        domains |= compile_source_text(text, preset.format)
+    return domains
+
+
+# ---------------------------------------------------------------------------
+# Rendering: DB rows -> dnsmasq config text
+# ---------------------------------------------------------------------------
+
+def device_tag(device_id: int) -> str:
+    """The dnsmasq DHCP tag a device is bound to (stable per device id)."""
+    return f"qmdev{device_id}"
+
+
+def render_tags(devices: Iterable[Any]) -> str:
+    """Bind every known MAC to its own DHCP tag (``qmdev<id>``).
+
+    This is what makes per-device rules possible at all: dnsmasq selects
+    config lines by tag, and a tag is assigned per-MAC via ``dhcp-host``.
+    Written to its own file (kept separate from :func:`render_rules`'s
+    output) so a domain-rule edit — which happens far more often than a
+    device being added — never rewrites this file too.
+    """
+    lines = [
+        "# Quota Manager — generated, do not edit by hand.",
+        "# Binds every known device MAC to its own dnsmasq tag so domain",
+        "# rules / DNS-server overrides can be scoped per device or per user.",
+    ]
+    for dev in devices:
+        mac = getattr(dev, "mac", None)
+        dev_id = getattr(dev, "id", None)
+        if not mac or dev_id is None or not _is_safe_config_token(mac):
+            continue
+        lines.append(f"dhcp-host={mac},set:{device_tag(dev_id)}")
+    return "\n".join(lines) + "\n"
+
+
+def _tags_for(scope: str, scope_id: Optional[int],
+             device_ids_by_user: dict[int, list[int]]) -> list[Optional[str]]:
+    """Every dnsmasq tag a rule/server override at this scope expands to.
+
+    ``global`` has no tag (applies to everyone). ``device`` is exactly one
+    tag. ``user`` expands to one tag PER device that user currently owns —
+    dnsmasq only understands per-device tags, so a user-level rule/override
+    is fanned out to every device belonging to that user at render time
+    (mirrors how ``service.resolve_device_state`` fans a user-level admin
+    cut out to devices, just at the DNS layer instead of nftables).
+    """
+    if scope == SCOPE_GLOBAL:
+        return [None]
+    if scope == SCOPE_DEVICE:
+        return [device_tag(scope_id)] if scope_id is not None else []
+    if scope == SCOPE_USER:
+        return [device_tag(d) for d in device_ids_by_user.get(scope_id, [])]
+    return []
+
+
+def _is_safe_config_token(value: str) -> bool:
+    """True if ``value`` cannot break out of a single generated config line.
+
+    Defense in depth: the API layer (api/schemas.py) already validates
+    ``target_ip``/``dns_server`` as bare IP addresses before they ever reach
+    here, but the renderer must never trust that as the ONLY gate — a future
+    caller of render_rules/render_tags that skips the API (a script, a
+    future non-HTTP path) must not be able to smuggle a newline into a
+    dnsmasq directive. Rejects any whitespace/control character.
+    """
+    return bool(value) and value == value.strip() and "\n" not in value \
+        and "\r" not in value and not any(c.isspace() for c in value)
+
+
+def render_rules(rules: Iterable[Any], dns_servers: Iterable[tuple[str, Optional[int], str]],
+                 device_ids_by_user: dict[int, list[int]]) -> str:
+    """Render domain rules (block/allow/redirect) + per-client DNS-server
+    overrides into one dnsmasq config file.
+
+    ``rules`` are DomainRule-like objects (``scope``/``scope_id``/``action``/
+    ``domain``/``target_ip``/``enabled``). ``dns_servers`` are
+    ``(scope, scope_id, ip)`` triples for the per-user/per-device
+    upstream-DNS-server feature.
+
+    Ordering: rules are rendered global-first, then user-scope, then
+    device-scope, and within the same scope, block/redirect before allow.
+    For an EXACT-same-domain-string conflict, dnsmasq's own behaviour is
+    "the later directive for that tag wins", so this ordering lets a
+    narrower scope (or an allow rule) override a broader one. It does NOT
+    matter for the common case of allowing a more specific subdomain of a
+    blocked parent domain — dnsmasq's longest-match already picks the more
+    specific rule regardless of file order.
+    """
+    lines = [
+        "# Quota Manager — generated, do not edit by hand.",
+        "# Domain rules (block/allow/redirect) + per-client DNS-server overrides.",
+    ]
+
+    ordered = sorted(
+        rules,
+        key=lambda r: (
+            _SCOPE_ORDER.get(getattr(r, "scope", SCOPE_GLOBAL), 0),
+            1 if getattr(r, "action", ACTION_BLOCK) == ACTION_ALLOW else 0,
+        ),
+    )
+
+    for rule in ordered:
+        if not getattr(rule, "enabled", True):
+            continue
+        action = getattr(rule, "action", ACTION_BLOCK)
+        domain = getattr(rule, "domain", "")
+        if not domain or not _is_safe_config_token(domain):
+            log.warning("skipping domain rule with unsafe/empty domain %r", domain)
+            continue
+        scope = getattr(rule, "scope", SCOPE_GLOBAL)
+        scope_id = getattr(rule, "scope_id", None)
+        if action == ACTION_ALLOW:
+            target: Optional[str] = None  # no override -> resolves normally
+        elif action == ACTION_REDIRECT:
+            target = getattr(rule, "target_ip", None) or "0.0.0.0"
+            if not _is_safe_config_token(target):
+                log.warning("skipping redirect rule with unsafe target_ip %r "
+                          "for domain %s", target, domain)
+                continue
+        else:  # block
+            target = "0.0.0.0"
+        for tag in _tags_for(scope, scope_id, device_ids_by_user):
+            prefix = f"tag:{tag} " if tag else ""
+            if target is None:
+                # Re-point the domain at the normal upstream chain for this
+                # tag scope, clearing any broader-scope blackhole for it.
+                lines.append(f"{prefix}server=/{domain}/#")
+            else:
+                lines.append(f"{prefix}address=/{domain}/{target}")
+
+    for scope, scope_id, ip in dns_servers:
+        if not ip or not _is_safe_config_token(ip):
+            if ip:
+                log.warning("skipping DNS-server override with unsafe value %r", ip)
+            continue
+        for tag in _tags_for(scope, scope_id, device_ids_by_user):
+            prefix = f"tag:{tag} " if tag else ""
+            lines.append(f"{prefix}server={ip}")
+
+    return "\n".join(lines) + "\n"
+
+
+def resolve_domain_status(domain: str, rules: Iterable[Any],
+                          device_id: Optional[int] = None,
+                          user_id: Optional[int] = None
+                          ) -> tuple[str, Optional[Any]]:
+    """What would actually happen to a lookup for ``domain`` right now, for
+    ``device_id`` (optionally owned by ``user_id``) — or, with both left
+    ``None``, considering only global-scope rules (the aggregate "all
+    devices" history view, where no single device's rules apply).
+
+    Mirrors dnsmasq's own matching exactly, so this reports the SAME answer
+    the live config would give, not an approximation:
+
+    * longest-domain-match wins first (a rule for ``ads.example.com`` beats
+      one for ``example.com`` regardless of scope) — this is dnsmasq's own
+      matching rule, not an ordering choice made here;
+    * among rules tied on domain length, the same scope/action ordering
+      :func:`render_rules` renders in decides it (global < user < device;
+      allow after block within a scope) — because that ordering is exactly
+      "last directive for this tag wins", the last-sorted candidate here IS
+      the one dnsmasq would actually apply.
+
+    Returns ``(status, rule)`` where ``status`` is one of ``"blocked"``,
+    ``"allowed"``, ``"redirected"``, or ``"none"`` (no rule reaches this
+    domain for this device), and ``rule`` is the winning DomainRule (or
+    ``None`` for ``"none"``).
+    """
+    candidates = []
+    for rule in rules:
+        if not getattr(rule, "enabled", True):
+            continue
+        rule_domain = getattr(rule, "domain", "")
+        if not rule_domain:
+            continue
+        if domain != rule_domain and not domain.endswith("." + rule_domain):
+            continue  # dnsmasq's own domain match: exact, or a subdomain
+        scope = getattr(rule, "scope", SCOPE_GLOBAL)
+        scope_id = getattr(rule, "scope_id", None)
+        if scope == SCOPE_GLOBAL:
+            applies = True
+        elif scope == SCOPE_DEVICE:
+            applies = device_id is not None and scope_id == device_id
+        elif scope == SCOPE_USER:
+            applies = user_id is not None and scope_id == user_id
+        else:
+            applies = False
+        if applies:
+            candidates.append(rule)
+    if not candidates:
+        return "none", None
+    # Longest domain match first (dnsmasq's real rule), then the same
+    # scope/action tiebreak render_rules sorts by — "last directive wins"
+    # for equally-specific rules, so the LAST item after this sort is the
+    # one actually in effect.
+    candidates.sort(key=lambda r: (
+        len(getattr(r, "domain", "")),
+        _SCOPE_ORDER.get(getattr(r, "scope", SCOPE_GLOBAL), 0),
+        1 if getattr(r, "action", ACTION_BLOCK) == ACTION_ALLOW else 0,
+    ))
+    winner = candidates[-1]
+    action = getattr(winner, "action", ACTION_BLOCK)
+    status = {"block": "blocked", "allow": "allowed",
+             "redirect": "redirected"}.get(action, "none")
+    return status, winner
+
+
+# ---------------------------------------------------------------------------
+# The manager: writes the two files, reloads dnsmasq only when something
+# actually changed (same signature-gated pattern as the nftables blocked set
+# and the tc tree — see Structure_README.md "Key design decisions").
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DnsRuleManager:
+    conf_dir: str = "/etc/dnsmasq.d"
+    tags_file: str = "quota-tags.conf"
+    rules_file: str = "quota-domains.conf"
+    reload_dnsmasq: bool = True
+
+    def _write_if_changed(self, path: Path, content: str) -> bool:
+        try:
+            if path.exists() and path.read_text(encoding="utf-8") == content:
+                return False
+        except OSError:
+            pass
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            log.error("could not write %s: %s (run as root on the gateway?)",
+                      path, exc)
+            return False
+        return True
+
+    def apply(self, devices: Iterable[Any], rules: Iterable[Any],
+             dns_servers: Iterable[tuple[str, Optional[int], str]],
+             device_ids_by_user: dict[int, list[int]]) -> bool:
+        """Render + write both files. Reloads dnsmasq only if a file's
+        content actually changed. Returns True if a reload was triggered."""
+        tags_text = render_tags(devices)
+        rules_text = render_rules(rules, dns_servers, device_ids_by_user)
+        tags_path = Path(self.conf_dir) / self.tags_file
+        rules_path = Path(self.conf_dir) / self.rules_file
+        tags_changed = self._write_if_changed(tags_path, tags_text)
+        rules_changed = self._write_if_changed(rules_path, rules_text)
+        changed = tags_changed or rules_changed
+        if changed and self.reload_dnsmasq:
+            self._reload()
+        return changed
+
+    def _reload(self) -> None:
+        # `dnsmasq --test` validates the WHOLE effective config (base file +
+        # every conf-dir file), the same check the setup script runs after
+        # writing quota-gateway.conf. Everything this module writes comes
+        # from normalize_pattern-validated input, so a failure here would
+        # mean a bug — but a bad config must never be allowed to take DHCP +
+        # DNS down for the whole household, so this is a hard gate.
+        try:
+            probe = subprocess.run(
+                ["dnsmasq", "--test"], capture_output=True, text=True, timeout=10)
+            if probe.returncode != 0:
+                log.error("generated dnsmasq config failed validation — NOT "
+                          "reloading: %s", probe.stderr.strip())
+                return
+        except FileNotFoundError:
+            log.warning("`dnsmasq` binary not found — skipping the pre-reload "
+                       "validation check (reloading anyway)")
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.warning("could not run `dnsmasq --test` (%s) — reloading anyway", exc)
+        try:
+            subprocess.run(["systemctl", "restart", "dnsmasq"],
+                           capture_output=True, text=True, timeout=15, check=True)
+            log.info("dnsmasq restarted to apply DNS filtering rule changes")
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.error("failed to restart dnsmasq after a DNS rule change: %s", exc)

--- a/run.py
+++ b/run.py
@@ -42,6 +42,7 @@ from api.app import create_app
 from core import config as cfg_mod
 from core.logging_setup import setup_logging
 from quota import db as _db
+from quota import dns_rules as _dns_rules
 from quota.arp_scan import ArpScanner
 from quota.dnslog import DnslogTailer
 from quota.engine import GATEWAY_MAC, EngineSnapshot, SnapshotHolder
@@ -72,6 +73,20 @@ def _make_shaper(cfg: cfg_mod.Config):
                     "speed limits + low-latency queues off")
         return None
     return TcShaper(cfg)
+
+
+def _make_dns_manager(cfg: cfg_mod.Config) -> _dns_rules.DnsRuleManager | None:
+    """Build the DNS-filtering config writer, or None when disabled."""
+    dns_cfg = getattr(cfg, "dns_filter", None)
+    if dns_cfg is not None and not dns_cfg.enabled:
+        log.warning("DNS filtering disabled in config — domain rules, "
+                    "presets, and per-client DNS-server overrides are inert")
+        return None
+    if dns_cfg is None:
+        return _dns_rules.DnsRuleManager()
+    return _dns_rules.DnsRuleManager(
+        conf_dir=dns_cfg.conf_dir, tags_file=dns_cfg.tags_file,
+        rules_file=dns_cfg.rules_file, reload_dnsmasq=dns_cfg.reload_dnsmasq)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -112,6 +127,7 @@ class Gateway:
         self.holder = SnapshotHolder()
         self.engine: NftablesEngine | None = None
         self.shaper: object | None = None  # quota.shaping.TcShaper (tc/ifb)
+        self.dns_manager: _dns_rules.DnsRuleManager | None = None  # domain filtering
         self.arp_lock: object | None = None  # quota.arp_lock.ArpLock (opt-in)
         # Built in startup(), AFTER the DB topology override: the scanner
         # resolves its probe networks from cfg at construction, so building it
@@ -144,6 +160,10 @@ class Gateway:
         #: briefly undo the user's fresh caps. Whoever runs second re-reads the
         #: DB, so the lock makes both orderings end on the fresh state.
         self._shaping_lock = asyncio.Lock()
+        #: serializes DNS-rule regeneration the same way ``_shaping_lock``
+        #: does for the tc tree (a maintenance tick and an API-triggered
+        #: immediate apply must not race each other's DB read + file write).
+        self._dns_lock = asyncio.Lock()
         self._maintenance_task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
 
@@ -183,6 +203,14 @@ class Gateway:
         self.shaper = _make_shaper(self.cfg)
         if self.shaper is not None:
             self.shaper.start()
+
+        # -- DNS filtering (dnsmasq domain rules + per-client DNS servers) --
+        # Pure config-generation, no kernel/socket state to "start" — built
+        # here (not __init__) for symmetry with the shaper/dnslog and so a
+        # future config-driven rebuild has the same lifecycle shape. An
+        # initial apply happens after the maintenance loop's first tick
+        # (device tags need a device list), not here — see _maintenance_tick.
+        self.dns_manager = _make_dns_manager(self.cfg)
 
         # -- ARP gateway-lock (opt-in) ---------------------------------------
         # Deny internet to devices that bypass the box by using the ROUTER as
@@ -583,6 +611,12 @@ class Gateway:
         #    touch the kernel; a DB edit lands here within one tick (<=15 s).
         await self._sync_shaping(ip_to_mac)
 
+        # 6. Regenerate dnsmasq's domain-rule + tag config if anything
+        #    changed (new device -> new tag, or a rule/preset/DNS-server
+        #    edit that arrived without going through the API's immediate
+        #    apply — e.g. a test or a future non-HTTP caller).
+        await self._sync_dns_rules()
+
     async def _sync_shaping(self, ip_to_mac: dict[str, str]) -> None:
         """Push the latest shaping settings + device caps into the tc shaper.
 
@@ -632,6 +666,51 @@ class Gateway:
             await self._sync_shaping(self._last_ip_to_mac)
         except Exception:  # noqa: BLE001
             log.exception("failed to apply speed-limit change immediately")
+
+    async def _sync_dns_rules(self) -> None:
+        """Regenerate the dnsmasq domain-rule + tag config from the DB and
+        reload dnsmasq if anything changed.
+
+        Mirrors ``_sync_shaping``: reads devices/users/rules fresh every
+        call and lets ``DnsRuleManager.apply`` decide (by content diff)
+        whether a reload is actually needed, so a call with nothing new to
+        say is free. Called once per maintenance tick (new devices need a
+        tag even with no rule edits) and immediately after any DNS-related
+        API edit via ``_apply_dns_now``.
+        """
+        manager = self.dns_manager
+        if manager is None:
+            return
+        try:
+            async with self._dns_lock:
+                devices = await self.database.list_devices()
+                users = {u.id: u for u in await self.database.list_users()}
+                rules = await self.database.list_domain_rules(enabled_only=True)
+                device_ids_by_user: dict[int, list[int]] = {}
+                for dev in devices:
+                    if dev.user_id is not None:
+                        device_ids_by_user.setdefault(dev.user_id, []).append(dev.id)
+                # Per-client DNS-server overrides: a device's own override
+                # wins; otherwise it inherits its user's override (if any).
+                # Rendered as (scope, scope_id, ip) triples, same shape as a
+                # domain rule's scope so render_rules' _tags_for is reused.
+                dns_servers: list[tuple[str, int | None, str]] = []
+                for user in users.values():
+                    if user.dns_server:
+                        dns_servers.append((_db.DNS_SCOPE_USER, user.id, user.dns_server))
+                for dev in devices:
+                    if dev.dns_server:
+                        dns_servers.append((_db.DNS_SCOPE_DEVICE, dev.id, dev.dns_server))
+                await asyncio.to_thread(
+                    manager.apply, devices, rules, dns_servers, device_ids_by_user)
+        except Exception:  # noqa: BLE001
+            log.exception("failed to sync DNS filtering rules")
+
+    async def _apply_dns_now(self) -> None:
+        """Apply a domain-rule / preset / DNS-server edit immediately instead
+        of waiting for the next maintenance tick. The API schedules this
+        after every /api/dns/* and /api/{users,devices}/{id}/dns edit."""
+        await self._sync_dns_rules()
 
     async def _wan_status(self) -> dict[str, object]:
         """Live WAN-mode status for the dashboard/API (cheap, every 15 s tick).
@@ -766,7 +845,8 @@ def main() -> None:
                          log_path=cfg.log_file,
                          topology_manager=gateway.topology_manager,
                          shaping_sync=gateway._reshaping_now,
-                         report_config=report_cfg)
+                         report_config=report_cfg,
+                         dns_apply=gateway._apply_dns_now)
         server_config = uvicorn.Config(
             app,
             host=cfg.web.host,

--- a/scripts/setup_gateway_kali.sh
+++ b/scripts/setup_gateway_kali.sh
@@ -530,6 +530,18 @@ else
     warn "dnsmasq query-log fragment did not validate — browsing history will be empty"
 fi
 
+# --- 4.6. dnsmasq: domain-filtering base files (blacklists/DNS overrides) ---
+# quota/dns_rules.py (the DNS-filtering feature) writes generated rules into
+# these two files whenever the admin edits a domain rule / preset / per-client
+# DNS server in the dashboard. They start EMPTY here — the app owns their
+# content from the first rule onward. conf-dir is already guaranteed active
+# by step 4 above, so this step is just the placeholder files, nothing else.
+log "[4.6/8] preparing dnsmasq domain-filtering files (empty until rules are added)"
+for f in quota-tags.conf quota-domains.conf; do
+    [ -f "/etc/dnsmasq.d/$f" ] || printf '# Quota Manager — generated, do not edit by hand.\n' \
+        > "/etc/dnsmasq.d/$f"
+done
+
 # --- 5. nftables: NAT for the client subnet ----------------------------------
 log "[5/8] writing nftables NAT ruleset"
 # The app (run.py, quota/nftables.py) owns the `inet quota_gateway` table —

--- a/tests/test_dns_rules.py
+++ b/tests/test_dns_rules.py
@@ -1,0 +1,350 @@
+"""Tests for quota/dns_rules.py: hosts/AdBlock-Plus parsing, wildcard
+normalization, and the dnsmasq tag/rule renderer + file-writing manager.
+
+Pure-function tests (parsing, normalization, rendering) need no root, no
+dnsmasq, and no network — they only assert on generated text. The
+DnsRuleManager tests use a tmp_path conf_dir and reload_dnsmasq=False so they
+never shell out to `dnsmasq`/`systemctl` (mirrors how test_shaping.py avoids
+touching the real `tc` binary).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from quota import dns_rules as dr
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+def test_parse_hosts_format_extracts_domains():
+    text = (
+        "# comment\n"
+        "0.0.0.0 ads.example.com\n"
+        "127.0.0.1 tracker.example.net  # inline comment\n"
+        "0.0.0.0 localhost\n"          # must be skipped
+        "not a hosts line\n"
+        "\n"
+    )
+    assert dr.parse_hosts_format(text) == {"ads.example.com", "tracker.example.net"}
+
+
+def test_parse_adblock_plus_extracts_domain_rules_only():
+    text = (
+        "! this is a comment\n"
+        "[Adblock Plus 2.0]\n"
+        "||ads.example.com^\n"
+        "||tracker.example.net^$third-party\n"
+        "@@||safe.example.com^\n"          # exception — must NOT be blocked
+        "##.ad-banner\n"                    # element-hiding — no DNS equivalent
+        "/some/path/rule\n"                 # path rule — no DNS equivalent
+    )
+    assert dr.parse_adblock_plus(text) == {"ads.example.com", "tracker.example.net"}
+
+
+def test_compile_source_text_auto_detects_format():
+    hosts_text = "0.0.0.0 ads.example.com\n"
+    abp_text = "||ads.example.com^\n"
+    assert dr.compile_source_text(hosts_text, "auto") == {"ads.example.com"}
+    assert dr.compile_source_text(abp_text, "auto") == {"ads.example.com"}
+
+
+# ---------------------------------------------------------------------------
+# Wildcard / pattern normalization
+# ---------------------------------------------------------------------------
+
+def test_normalize_pattern_strips_leading_wildcard():
+    # dnsmasq's domain match already includes every subdomain, so "*." is
+    # just a no-op on top of the plain-domain match — stripped, not kept.
+    assert dr.normalize_pattern("*.example.com") == "example.com"
+    assert dr.normalize_pattern("EXAMPLE.com.") == "example.com"
+
+
+def test_normalize_pattern_rejects_midlabel_wildcard():
+    # Not something dnsmasq's exact-domain match can enforce.
+    with pytest.raises(ValueError):
+        dr.normalize_pattern("*.ads.*.example.com")
+    with pytest.raises(ValueError):
+        dr.normalize_pattern("ads*.example.com")
+
+
+def test_normalize_pattern_rejects_empty_or_garbage():
+    with pytest.raises(ValueError):
+        dr.normalize_pattern("")
+    with pytest.raises(ValueError):
+        dr.normalize_pattern("not a domain!!")
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeDevice:
+    id: int
+    mac: str
+
+
+@dataclass
+class _FakeRule:
+    scope: str
+    scope_id: Optional[int]
+    action: str
+    domain: str
+    target_ip: Optional[str] = None
+    enabled: bool = True
+
+
+def test_render_tags_binds_every_device_mac():
+    devices = [_FakeDevice(1, "aa:bb:cc:dd:ee:01"), _FakeDevice(2, "aa:bb:cc:dd:ee:02")]
+    text = dr.render_tags(devices)
+    assert "dhcp-host=aa:bb:cc:dd:ee:01,set:qmdev1" in text
+    assert "dhcp-host=aa:bb:cc:dd:ee:02,set:qmdev2" in text
+
+
+def test_render_rules_global_block_has_no_tag_prefix():
+    rules = [_FakeRule("global", None, "block", "ads.example.com")]
+    text = dr.render_rules(rules, [], {})
+    assert "address=/ads.example.com/0.0.0.0" in text
+    assert "tag:" not in text
+
+
+def test_render_rules_device_scope_is_tag_restricted():
+    rules = [_FakeRule("device", 7, "block", "tiktok.com")]
+    text = dr.render_rules(rules, [], {})
+    assert "tag:qmdev7 address=/tiktok.com/0.0.0.0" in text
+
+
+def test_render_rules_user_scope_fans_out_to_every_owned_device():
+    rules = [_FakeRule("user", 42, "block", "netflix.com")]
+    device_ids_by_user = {42: [1, 2, 3]}
+    text = dr.render_rules(rules, [], device_ids_by_user)
+    for dev_id in (1, 2, 3):
+        assert f"tag:qmdev{dev_id} address=/netflix.com/0.0.0.0" in text
+
+
+def test_render_rules_redirect_uses_target_ip():
+    rules = [_FakeRule("global", None, "redirect", "printer.local", target_ip="192.168.2.50")]
+    text = dr.render_rules(rules, [], {})
+    assert "address=/printer.local/192.168.2.50" in text
+
+
+def test_render_rules_rejects_config_injection_in_target_ip():
+    # Defense in depth: even if a malformed target_ip somehow reaches the
+    # renderer (the API layer should already reject it — see
+    # test_api_rejects_config_injection_in_target_ip below), it must never
+    # be written verbatim into a line dnsmasq will parse as two directives.
+    rules = [_FakeRule("global", None, "redirect", "evil.example.com",
+                       target_ip="1.1.1.1\nno-resolv")]
+    text = dr.render_rules(rules, [], {})
+    assert "no-resolv" not in text
+    assert "evil.example.com" not in text  # the whole rule is dropped, not truncated
+
+
+def test_render_rules_rejects_config_injection_in_dns_server():
+    text = dr.render_rules([], [("device", 5, "1.1.1.1\nserver=evil")], {})
+    assert "evil" not in text
+
+
+def test_render_rules_disabled_rule_is_skipped():
+    rules = [_FakeRule("global", None, "block", "ads.example.com", enabled=False)]
+    text = dr.render_rules(rules, [], {})
+    assert "ads.example.com" not in text
+
+
+def test_render_rules_allow_renders_after_block_for_override():
+    # A device-scoped allow for the SAME domain as a global block must come
+    # after it in the file so dnsmasq's "last directive wins" gives the
+    # allow priority for that exact device.
+    rules = [
+        _FakeRule("global", None, "block", "example.com"),
+        _FakeRule("device", 3, "allow", "example.com"),
+    ]
+    text = dr.render_rules(rules, [], {})
+    block_idx = text.index("address=/example.com/0.0.0.0")
+    allow_idx = text.index("tag:qmdev3 server=/example.com/#")
+    assert block_idx < allow_idx
+
+
+def test_render_rules_dns_server_overrides():
+    text = dr.render_rules([], [("device", 5, "1.1.1.1"), ("global", None, "9.9.9.9")], {})
+    assert "tag:qmdev5 server=1.1.1.1" in text
+    assert "server=9.9.9.9" in text
+
+
+# ---------------------------------------------------------------------------
+# DnsRuleManager (file writing, no real dnsmasq/systemctl involved)
+# ---------------------------------------------------------------------------
+
+def test_manager_writes_both_files(tmp_path: Path):
+    manager = dr.DnsRuleManager(conf_dir=str(tmp_path), reload_dnsmasq=False)
+    devices = [_FakeDevice(1, "aa:bb:cc:dd:ee:01")]
+    rules = [_FakeRule("global", None, "block", "ads.example.com")]
+    changed = manager.apply(devices, rules, [], {})
+    assert changed is True
+    assert (tmp_path / "quota-tags.conf").exists()
+    assert (tmp_path / "quota-domains.conf").exists()
+    assert "qmdev1" in (tmp_path / "quota-tags.conf").read_text()
+    assert "ads.example.com" in (tmp_path / "quota-domains.conf").read_text()
+
+
+def test_manager_apply_is_signature_gated(tmp_path: Path):
+    """A second identical apply() must report no change (nothing to
+    reload) — same pattern as the nftables blocked set / tc tree."""
+    manager = dr.DnsRuleManager(conf_dir=str(tmp_path), reload_dnsmasq=False)
+    devices = [_FakeDevice(1, "aa:bb:cc:dd:ee:01")]
+    rules = [_FakeRule("global", None, "block", "ads.example.com")]
+    assert manager.apply(devices, rules, [], {}) is True
+    assert manager.apply(devices, rules, [], {}) is False  # unchanged
+    rules2 = [_FakeRule("global", None, "block", "tracker.example.net")]
+    assert manager.apply(devices, rules2, [], {}) is True  # content changed
+
+
+# ---------------------------------------------------------------------------
+# Presets registry sanity
+# ---------------------------------------------------------------------------
+
+def test_streaming_preset_has_no_urls_and_uses_curated_list():
+    preset = dr.PRESETS["streaming"]
+    assert preset.urls == []
+    assert dr.fetch_preset(preset) == dr.STREAMING_DOMAINS
+
+
+def test_social_media_preset_lists_cyb3rko_sources():
+    preset = dr.PRESETS["social-media"]
+    assert any("cyb3rko/social-media-hosts-blocklists" in u for u in preset.urls)
+
+
+# ---------------------------------------------------------------------------
+# DB-layer CRUD (quota/db.py's domain_rules / dns_presets / dns_server cols)
+# ---------------------------------------------------------------------------
+
+import asyncio  # noqa: E402  (grouped with the DB-test section, not the top)
+
+from quota import db as _db  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_domain_rule_crud_roundtrip(tmp_path: Path):
+    async def _body():
+        database = _db.Database(tmp_path / "q.db")
+        await database.connect()
+        rule = await database.create_domain_rule(
+            "global", "block", "ads.example.com")
+        assert rule.id > 0
+        assert rule.source == "manual"
+
+        fetched = await database.get_domain_rule(rule.id)
+        assert fetched is not None and fetched.domain == "ads.example.com"
+
+        listed = await database.list_domain_rules()
+        assert len(listed) == 1
+
+        await database.update_domain_rule(rule.id, enabled=False)
+        disabled = await database.get_domain_rule(rule.id)
+        assert disabled.enabled is False
+
+        await database.delete_domain_rule(rule.id)
+        assert await database.get_domain_rule(rule.id) is None
+        await database.close()
+    _run(_body())
+
+
+def test_domain_rule_scoped_delete_on_device_removal(tmp_path: Path):
+    async def _body():
+        database = _db.Database(tmp_path / "q.db")
+        await database.connect()
+        dev = await database.upsert_device("aa:bb:cc:dd:ee:01", name="phone")
+        await database.create_domain_rule(
+            "device", "block", "tiktok.com", scope_id=dev.id)
+        assert len(await database.list_domain_rules()) == 1
+        await database.delete_device(dev.id)
+        # The device-scoped rule is orphaned once its device (and dnsmasq
+        # tag) is gone, so delete_device sweeps it too.
+        assert await database.list_domain_rules() == []
+        await database.close()
+    _run(_body())
+
+
+def test_device_and_user_dns_server_persist(tmp_path: Path):
+    async def _body():
+        database = _db.Database(tmp_path / "q.db")
+        await database.connect()
+        user = await database.create_user(name="kid")
+        await database.update_user(user.id, dns_server="1.1.1.3")
+        refreshed = await database.get_user(user.id)
+        assert refreshed.dns_server == "1.1.1.3"
+
+        dev = await database.upsert_device("aa:bb:cc:dd:ee:02", name="tablet",
+                                           user_id=user.id)
+        await database.update_device(dev.id, dns_server="9.9.9.9")
+        refreshed_dev = await database.get_device(dev.id)
+        assert refreshed_dev.dns_server == "9.9.9.9"
+        await database.close()
+    _run(_body())
+
+
+def test_preset_state_roundtrip(tmp_path: Path):
+    async def _body():
+        database = _db.Database(tmp_path / "q.db")
+        await database.connect()
+        assert await database.get_preset_state("ads-tracking") is None
+        await database.set_preset_state("ads-tracking", True, domain_count=1234)
+        state = await database.get_preset_state("ads-tracking")
+        assert state["enabled"] == 1
+        assert state["domain_count"] == 1234
+        await database.set_preset_state("ads-tracking", False, domain_count=0)
+        state = await database.get_preset_state("ads-tracking")
+        assert state["enabled"] == 0
+        await database.close()
+    _run(_body())
+
+
+# ---------------------------------------------------------------------------
+# API-layer validation (api/schemas.py) — the FIRST line of defense against
+# config injection via target_ip / dns_server; quota/dns_rules.py's
+# _is_safe_config_token tests above are the second (defense in depth).
+# ---------------------------------------------------------------------------
+
+def test_api_rejects_config_injection_in_target_ip():
+    from pydantic import ValidationError
+
+    from api.schemas import DomainRuleCreate
+
+    with pytest.raises(ValidationError):
+        DomainRuleCreate(scope="global", action="redirect",
+                         domain="evil.example.com",
+                         target_ip="1.1.1.1\nno-resolv")
+
+
+def test_api_accepts_valid_target_ip():
+    from api.schemas import DomainRuleCreate
+
+    rule = DomainRuleCreate(scope="global", action="redirect",
+                            domain="printer.local", target_ip="192.168.2.50")
+    assert rule.target_ip == "192.168.2.50"
+
+
+def test_api_rejects_config_injection_in_dns_server():
+    from pydantic import ValidationError
+
+    from api.schemas import DnsServerUpdate
+
+    with pytest.raises(ValidationError):
+        DnsServerUpdate(dns_server="1.1.1.1\nserver=evil")
+
+
+def test_api_accepts_empty_dns_server_as_clear():
+    from api.schemas import DnsServerUpdate
+
+    assert DnsServerUpdate(dns_server="").dns_server == ""
+    assert DnsServerUpdate(dns_server="9.9.9.9").dns_server == "9.9.9.9"

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -61,8 +61,8 @@ def test_index_served(client):
     assert "System logs" in r.text
     assert 'id="panel-logs"' in r.text
     assert 'class="glass card admin-card"' in r.text
-    assert "assets/app.js?v=32" in r.text
-    assert "assets/styles.css?v=37" in r.text
+    assert "assets/app.js?v=33" in r.text
+    assert "assets/styles.css?v=38" in r.text
     # the internet reachability pill lives in the top bar, not the WAN status
     # panel (probed every 15 s; dot color = reachability).
     assert 'id="net-status"' in r.text
@@ -266,8 +266,10 @@ def test_history_tab_present(client):
 
 
 def test_history_assets_bumped(client):
-    """The History "All devices" tab bumped the cache-busting tags (styles
-    34->36, app.js 31->32) so browsers drop the pre-All-devices assets."""
+    """Cache-busting tags track the newest UI change. History's "All devices"
+    tab took styles 34->37, app.js 31->32; the DNS-filtering tab (rules,
+    presets, import, history status badges/quick-actions) took them to
+    38/33 — this always checks the CURRENT baseline, not the original bump."""
     r = client.get("/")
-    assert "assets/styles.css?v=37" in r.text
-    assert "assets/app.js?v=32" in r.text
+    assert "assets/styles.css?v=38" in r.text
+    assert "assets/app.js?v=33" in r.text

--- a/web/assets/app.js
+++ b/web/assets/app.js
@@ -368,6 +368,7 @@ function switchPanel(name) {
   if (name === "network") refreshNetwork();
   if (name === "wan") refreshWan();
   if (name === "history") refreshHistory();
+  if (name === "dns") refreshDns();
 }
 
 async function refreshLogs() {
@@ -410,6 +411,45 @@ function histDeviceName(deviceId) {
     .find((x) => x.id === deviceId);
   if (!dev) return "#" + deviceId;
   return dev.user_name || dev.name || dev.mac;
+}
+
+// DNS-filter status badge (colored dot + label), and — for the "top
+// domains" table only — quick block/allow buttons that call
+// POST /api/dns/rules/quick. Buttons offer "this device" only when viewing
+// a specific device (aggregate/"all" has no single device to scope to).
+function dnsStatusBadge(status) {
+  const map = {
+    blocked: ["dns-badge blocked", "● Blocked"],
+    allowed: ["dns-badge allowed", "● Allowed"],
+    redirected: ["dns-badge redirected", "● Redirected"],
+    none: ["dns-badge none", "○ No rule"],
+  };
+  const [cls, label] = map[status] || map.none;
+  return `<span class="${cls}">${label}</span>`;
+}
+
+async function quickDnsRule(domain, action, scope, deviceId) {
+  try {
+    await API.post("/api/dns/rules/quick", {
+      domain, action, scope, device_id: deviceId ?? null,
+    });
+    await refreshHistory();
+  } catch (e) {
+    alert("Could not update the DNS rule: " + e.message);
+  }
+}
+
+function dnsQuickActions(domain, deviceId) {
+  const d = JSON.stringify(domain);
+  const devBtns = deviceId
+    ? `<button type="button" class="btn ghost tiny" onclick='quickDnsRule(${d},"block","device",${deviceId})'>Block device</button>`
+    : "";
+  return `
+    <div class="dns-quick-actions">
+      ${devBtns}
+      <button type="button" class="btn ghost tiny" onclick='quickDnsRule(${d},"block","global",null)'>Block everyone</button>
+      <button type="button" class="btn ghost tiny" onclick='quickDnsRule(${d},"allow","global",null)'>Allow</button>
+    </div>`;
 }
 
 async function refreshHistory() {
@@ -468,11 +508,13 @@ function renderHistory(d) {
   }
 
   // top domains
+  const curDeviceId = d.device_id === "all" ? null : d.device_id;
   $("hist-top").innerHTML = d.top_domains.map((t) => `
     <tr>
       <td class="domain">${esc(t.domain)}</td>
       <td class="num">${t.hits.toLocaleString()}</td>
       <td class="num">${total ? ((t.hits / total) * 100).toFixed(1) : "0.0"}%</td>
+      <td>${dnsStatusBadge(t.status)} ${dnsQuickActions(t.domain, curDeviceId)}</td>
     </tr>`).join("");
 
   // activity: group the per-minute buckets into hourly bars (no chart.js)
@@ -496,7 +538,7 @@ function renderHistory(d) {
       : "";
     return `
     <li>
-      <span class="domain">${badge}${esc(r.domain)}</span>
+      <span class="domain">${badge}${esc(r.domain)} ${dnsStatusBadge(r.status)}</span>
       <span class="num">${esc(r.bucket_minute)} × ${r.count}</span>
     </li>`;
   }).join("");
@@ -504,6 +546,146 @@ function renderHistory(d) {
 
 /* level filter + search are applied client-side to the raw /api/logs lines;
    the level is the 3rd whitespace token ("2026-08-06 12:00:00,123 INFO name: …") */
+/* ---------------- DNS tab: rules, presets, import ---------------- */
+
+let dnsPresetsCache = [];
+let dnsRulesCache = [];
+
+// scope-target selects (rule form + import form) share the same options:
+// every user, then every device, each tagged so submit knows which id/scope.
+function populateDnsTargetSelect(sel, scopeSel) {
+  const scope = scopeSel.value;
+  sel.classList.toggle("hidden", scope === "global");
+  if (scope === "global") return;
+  if (scope === "user") {
+    sel.innerHTML = (dashboard.users || [])
+      .map((u) => `<option value="${u.id}">${esc(u.name || `User #${u.id}`)}</option>`).join("");
+  } else {
+    sel.innerHTML = (dashboard.devices || [])
+      .map((d) => `<option value="${d.id}">${esc(d.name || d.mac)}</option>`).join("");
+  }
+}
+
+function scopeLabel(rule) {
+  if (rule.scope === "global") return "Global";
+  if (rule.scope === "user") {
+    const u = (dashboard.users || []).find((x) => x.id === rule.scope_id);
+    return `User: ${esc(u ? (u.name || `#${rule.scope_id}`) : `#${rule.scope_id}`)}`;
+  }
+  const dev = (dashboard.devices || []).find((x) => x.id === rule.scope_id);
+  return `Device: ${esc(dev ? (dev.name || dev.mac) : `#${rule.scope_id}`)}`;
+}
+
+function renderDnsRules() {
+  const list = $("dns-rules-list"), empty = $("dns-rules-empty");
+  if (!dnsRulesCache.length) {
+    list.innerHTML = "";
+    empty.classList.remove("hidden");
+    return;
+  }
+  empty.classList.add("hidden");
+  list.innerHTML = dnsRulesCache.map((r) => {
+    const actionLabel = r.action === "redirect" ? `Redirect → ${esc(r.target_ip || "")}` :
+      r.action === "allow" ? "Allow" : "Block";
+    return `
+    <tr>
+      <td>${scopeLabel(r)}</td>
+      <td class="domain">${esc(r.domain)}</td>
+      <td>${actionLabel}</td>
+      <td class="muted small">${esc(r.source)}</td>
+      <td><button type="button" class="btn ghost tiny" data-del-rule="${r.id}">Delete</button></td>
+    </tr>`;
+  }).join("");
+}
+
+function renderDnsPresets() {
+  $("dns-presets-list").innerHTML = dnsPresetsCache.map((p) => `
+    <div class="dns-preset-row">
+      <div>
+        <b>${esc(p.name)}</b>
+        <p class="muted small">${esc(p.description)}</p>
+        ${p.enabled ? `<span class="muted small">${p.domain_count.toLocaleString()} domains · ${scopeLabel({ scope: p.scope, scope_id: p.scope_id })}</span>` : ""}
+      </div>
+      <label class="switch" title="${p.enabled ? 'Disable' : 'Enable'} ${esc(p.name)}">
+        <input type="checkbox" data-preset-toggle="${p.id}" ${p.enabled ? "checked" : ""}>
+        <span class="slider"></span>
+      </label>
+    </div>`).join("");
+}
+
+async function refreshDns() {
+  try {
+    [dnsPresetsCache, dnsRulesCache] = await Promise.all([
+      API.get("/api/dns/presets"),
+      API.get("/api/dns/rules"),
+    ]);
+  } catch (_) { dnsPresetsCache = []; dnsRulesCache = []; }
+  renderDnsPresets();
+  renderDnsRules();
+  populateDnsTargetSelect($("dns-rule-target"), $("dns-rule-scope"));
+  populateDnsTargetSelect($("dns-import-target"), $("dns-import-scope"));
+}
+
+async function togglePreset(presetId, enable) {
+  const err = $("dns-rule-error");
+  err.classList.add("hidden");
+  try {
+    if (enable) {
+      await API.post(`/api/dns/presets/${presetId}/enable`, { scope: "global" });
+    } else {
+      await API.post(`/api/dns/presets/${presetId}/disable`, { scope: "global" });
+    }
+  } catch (e) {
+    err.textContent = "Preset update failed: " + e.message;
+    err.classList.remove("hidden");
+  }
+  await refreshDns();
+}
+
+async function submitDnsRule(ev) {
+  ev.preventDefault();
+  const err = $("dns-rule-error");
+  err.classList.add("hidden");
+  const scope = $("dns-rule-scope").value;
+  const scopeId = scope === "global" ? null : Number($("dns-rule-target").value) || null;
+  const action = $("dns-rule-action").value;
+  const domain = $("dns-rule-domain").value.trim();
+  const targetIp = $("dns-rule-target-ip").value.trim();
+  try {
+    const body = { scope, scope_id: scopeId, action, domain, enabled: true };
+    if (action === "redirect") body.target_ip = targetIp;
+    await API.post("/api/dns/rules", body);
+    $("dns-rule-domain").value = "";
+    $("dns-rule-target-ip").value = "";
+    await refreshDns();
+  } catch (e) {
+    err.textContent = e.message;
+    err.classList.remove("hidden");
+  }
+}
+
+async function submitDnsImport(ev) {
+  ev.preventDefault();
+  const result = $("dns-import-result");
+  const scope = $("dns-import-scope").value;
+  const scopeId = scope === "global" ? null : Number($("dns-import-target").value) || null;
+  try {
+    const res = await API.post("/api/dns/import", {
+      text: $("dns-import-text").value,
+      format: $("dns-import-format").value,
+      scope, scope_id: scopeId,
+      action: $("dns-import-action").value,
+    });
+    result.textContent = `Imported ${res.created} rule(s), skipped ${res.skipped} unenforceable line(s).`;
+    result.classList.remove("hidden");
+    $("dns-import-text").value = "";
+    await refreshDns();
+  } catch (e) {
+    result.textContent = "Import failed: " + e.message;
+    result.classList.remove("hidden");
+  }
+}
+
 function filterLogs() {
   let lines = logLines;
   if (logFilter !== "ALL") {
@@ -692,6 +874,7 @@ function openDeviceModal(id) {
   // per-device speed caps (Mbps, 0 = unlimited)
   $("d-limit-down").value = dev ? (dev.limit_down_mbps || 0) : 0;
   $("d-limit-up").value = dev ? (dev.limit_up_mbps || 0) : 0;
+  $("d-dns-server").value = dev ? (dev.dns_server || "") : "";
   $("d-fixed-wrap").classList.toggle("hidden", $("d-mode").value !== "fixed");
   $("modal-submit").textContent = dev ? "Save" : "Add";
   $("modal").classList.remove("hidden");
@@ -732,7 +915,9 @@ async function submitDevice(ev) {
   // per-device speed caps (Mbps, 0 = unlimited) — always sent, device-scoped
   const limitDown = Math.max(0, parseFloat($("d-limit-down").value) || 0);
   const limitUp = Math.max(0, parseFloat($("d-limit-up").value) || 0);
+  const dnsServer = $("d-dns-server").value.trim();
 
+  let targetDeviceId = editDeviceId;
   if (editDeviceId == null) {
     const mac = normalizeMac($("d-mac").value);
     if (!mac) { alert("Invalid MAC address."); return; }
@@ -745,7 +930,8 @@ async function submitDevice(ev) {
       body.quota_mode = mode;
       body.fixed_gb = fixed;
     }
-    await API.post("/api/devices", body);
+    const created = await API.post("/api/devices", body);
+    targetDeviceId = created.id;
   } else {
     const patch = { name, limit_down_mbps: limitDown, limit_up_mbps: limitUp };
     if (userId != null && userId !== originalUserId) patch.user_id = userId;
@@ -760,6 +946,13 @@ async function submitDevice(ev) {
       patch.fixed_gb = fixed;
     }
     await API.patch(`/api/devices/${editDeviceId}`, patch);
+  }
+  // dns_server has its own PATCH endpoint (validated as a bare IP there,
+  // see api/schemas.py's DnsServerUpdate) — a separate call either way,
+  // now that we have a real device id for a brand-new device too.
+  if (targetDeviceId != null) {
+    try { await API.patch(`/api/devices/${targetDeviceId}/dns`, { dns_server: dnsServer }); }
+    catch (e) { alert("Device saved, but the DNS server value was rejected: " + e.message); }
   }
   closeModal();
   await refreshAll();
@@ -784,6 +977,7 @@ function openUserModal(id) {
   $("u-speed-wrap").classList.remove("hidden");  // shown for new + existing users
   // per-user DNS-history retention (days); blank = global default
   $("u-history-days").value = u ? (u.history_days ?? "") : "";
+  $("u-dns-server").value = u ? (u.dns_server || "") : "";
   $("u-fixed-wrap").classList.toggle("hidden", $("u-mode").value !== "fixed");
   $("user-modal-submit").textContent = u ? "Save" : "Add";
   $("user-modal").classList.remove("hidden");
@@ -807,12 +1001,19 @@ async function submitUser(ev) {
   const historyDaysField = $("u-history-days").value;
   const historyDays = historyDaysField === "" ? null
     : Math.max(0, Math.min(365, parseInt(historyDaysField, 10) || 0));
+  const dnsServer = $("u-dns-server").value.trim();
+  let targetUserId = editUserId;
   if (editUserId == null) {
-    await API.post("/api/users", { name, quota_mode: mode, fixed_gb: fixed,
+    const created = await API.post("/api/users", { name, quota_mode: mode, fixed_gb: fixed,
       limit_down_mbps: limitDown, limit_up_mbps: limitUp });
+    targetUserId = created.id;
   } else {
     await API.patch(`/api/users/${editUserId}`, { name, quota_mode: mode, fixed_gb: fixed,
       limit_down_mbps: limitDown, limit_up_mbps: limitUp, history_days: historyDays });
+  }
+  if (targetUserId != null) {
+    try { await API.patch(`/api/users/${targetUserId}/dns`, { dns_server: dnsServer }); }
+    catch (e) { alert("User saved, but the DNS server value was rejected: " + e.message); }
   }
   closeUserModal();
   await refreshAll();
@@ -1351,6 +1552,24 @@ async function init() {
   $("hist-device").addEventListener("change", refreshHistory);
   $("hist-window").addEventListener("change", refreshHistory);
   $("hist-refresh").addEventListener("click", refreshHistory);
+  $("dns-rule-form").addEventListener("submit", submitDnsRule);
+  $("dns-import-form").addEventListener("submit", submitDnsImport);
+  $("dns-rule-scope").addEventListener("change", () =>
+    populateDnsTargetSelect($("dns-rule-target"), $("dns-rule-scope")));
+  $("dns-import-scope").addEventListener("change", () =>
+    populateDnsTargetSelect($("dns-import-target"), $("dns-import-scope")));
+  $("dns-rule-action").addEventListener("change", () =>
+    $("dns-rule-target-ip").classList.toggle("hidden", $("dns-rule-action").value !== "redirect"));
+  $("dns-presets-list").addEventListener("change", (ev) => {
+    const id = ev.target.dataset && ev.target.dataset.presetToggle;
+    if (id) togglePreset(id, ev.target.checked);
+  });
+  $("dns-rules-list").addEventListener("click", async (ev) => {
+    const id = ev.target.dataset && ev.target.dataset.delRule;
+    if (!id) return;
+    await API.del(`/api/dns/rules/${id}`);
+    await refreshDns();
+  });
   $("password-link").addEventListener("click", () => $("pwd-modal").classList.remove("hidden"));
   $("pwd-cancel").addEventListener("click", () => $("pwd-modal").classList.add("hidden"));
   $("pwd-form").addEventListener("submit", submitPassword);

--- a/web/assets/styles.css
+++ b/web/assets/styles.css
@@ -1003,3 +1003,52 @@ select option { background: #0f0b18; }
   .topbar { margin: 10px 10px 0; padding: 10px 12px; }
   body { padding-bottom: env(safe-area-inset-bottom); }
 }
+
+/* ---------- DNS filtering (presets, rules, import, history badges) ---------- */
+.dns-presets-list { display: flex; flex-direction: column; gap: 10px; }
+.dns-preset-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+}
+.dns-preset-row p { margin: 2px 0 0; }
+.dns-rule-form, .dns-import-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  align-items: center;
+}
+.dns-rule-form select, .dns-rule-form input,
+.dns-import-row select, .dns-import-row select + select {
+  flex: 1 1 140px;
+  min-width: 120px;
+}
+.dns-import-form textarea {
+  width: 100%;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.82rem;
+  resize: vertical;
+  margin-bottom: 8px;
+}
+.btn.tiny { padding: 4px 10px; font-size: 0.75rem; border-radius: 8px; }
+.dns-quick-actions { display: inline-flex; gap: 6px; margin-left: 8px; flex-wrap: wrap; }
+.dns-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.dns-badge.blocked { color: var(--danger); }
+.dns-badge.allowed { color: var(--ok); }
+.dns-badge.redirected { color: var(--warn); }
+.dns-badge.none { color: var(--text-dim); }
+
+@media (max-width: 720px) {
+  .dns-rule-form, .dns-import-row { flex-direction: column; align-items: stretch; }
+  .dns-preset-row { flex-direction: column; align-items: flex-start; }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Quota Manager</title>
-<link rel="stylesheet" href="/assets/styles.css?v=37">
+<link rel="stylesheet" href="/assets/styles.css?v=38">
 </head>
 <body>
   <div class="bg-glow"></div>
@@ -37,6 +37,7 @@
         <button class="nav-tab" data-panel="admin">Admin</button>
         <button class="nav-tab" data-panel="logs">Logs</button>
         <button class="nav-tab" data-panel="history">History</button>
+        <button class="nav-tab" data-panel="dns">DNS</button>
       </nav>
       <div class="topbar-right">
         <span id="net-status" class="net-status" title="Checking internet connection…">
@@ -432,7 +433,7 @@
             <div class="table-wrap">
               <table class="history-table">
                 <thead>
-                  <tr><th>Top domains</th><th class="num">Queries</th><th class="num">Share</th></tr>
+                  <tr><th>Top domains</th><th class="num">Queries</th><th class="num">Share</th><th>Filter</th></tr>
                 </thead>
                 <tbody id="hist-top"></tbody>
               </table>
@@ -448,6 +449,82 @@
               </div>
             </div>
           </div>
+        </div>
+      </section>
+
+      <!-- DNS: domain blacklist/allow/redirect rules, blocklist presets, -->
+      <!-- import, and per-user/per-device upstream DNS-server overrides. -->
+      <section id="panel-dns" class="nav-panel hidden">
+        <div class="glass card">
+          <h3>Blocklist presets</h3>
+          <p class="muted small">Ready-to-use domain lists. Enabling one fetches
+            + compiles its source(s) into rules for the household (or a
+            specific user/device below); disabling removes exactly those
+            rules again.</p>
+          <div id="dns-presets-list" class="dns-presets-list"></div>
+        </div>
+
+        <div class="glass card">
+          <h3>Domain rules</h3>
+          <p class="muted small">Block, allow, or redirect a domain (and every
+            subdomain of it) globally, for one user, or for one device.</p>
+          <form id="dns-rule-form" class="dns-rule-form">
+            <select id="dns-rule-scope" title="Scope">
+              <option value="global" selected>Global (everyone)</option>
+              <option value="user">One user</option>
+              <option value="device">One device</option>
+            </select>
+            <select id="dns-rule-target" class="hidden" title="User/device"></select>
+            <input id="dns-rule-domain" placeholder="example.com" required>
+            <select id="dns-rule-action" title="Action">
+              <option value="block" selected>Block</option>
+              <option value="allow">Allow (override a block)</option>
+              <option value="redirect">Redirect</option>
+            </select>
+            <input id="dns-rule-target-ip" class="hidden" placeholder="target IP">
+            <button type="submit" class="btn primary small">Add rule</button>
+          </form>
+          <p id="dns-rule-error" class="error hidden"></p>
+          <div class="table-wrap">
+            <table class="history-table">
+              <thead>
+                <tr><th>Scope</th><th>Domain</th><th>Action</th><th>Source</th><th></th></tr>
+              </thead>
+              <tbody id="dns-rules-list"></tbody>
+            </table>
+          </div>
+          <p id="dns-rules-empty" class="muted small hidden">No domain rules yet.</p>
+        </div>
+
+        <div class="glass card">
+          <h3>Import a blocklist</h3>
+          <p class="muted small">Paste a hosts-format (<code>0.0.0.0 domain</code>)
+            or AdBlock-Plus-format (<code>||domain^</code>) list. Only the
+            domain-shaped rules translate to DNS blocking — element-hiding
+            and path rules are skipped.</p>
+          <form id="dns-import-form" class="dns-import-form">
+            <textarea id="dns-import-text" rows="6"
+                      placeholder="0.0.0.0 ads.example.com&#10;||tracker.example.net^"></textarea>
+            <div class="dns-import-row">
+              <select id="dns-import-format" title="Format">
+                <option value="auto" selected>Auto-detect</option>
+                <option value="hosts">Hosts format</option>
+                <option value="adblock">AdBlock Plus format</option>
+              </select>
+              <select id="dns-import-scope" title="Scope">
+                <option value="global" selected>Global (everyone)</option>
+                <option value="user">One user</option>
+                <option value="device">One device</option>
+              </select>
+              <select id="dns-import-target" class="hidden" title="User/device"></select>
+              <select id="dns-import-action" title="Action">
+                <option value="block" selected>Block</option>
+                <option value="allow">Allow</option>
+              </select>
+              <button type="submit" class="btn ghost small">Import</button>
+            </div>
+          </form>
+          <p id="dns-import-result" class="muted small hidden"></p>
         </div>
       </section>
     </main>
@@ -508,6 +585,8 @@
           <label for="d-topup">Top up (extra GB)</label>
           <input type="number" id="d-topup" min="0.1" step="any" placeholder="0">
         </div>
+        <label for="d-dns-server">Upstream DNS server (blank = inherit)</label>
+        <input id="d-dns-server" placeholder="e.g. 1.1.1.1">
         <div class="modal-actions">
           <button type="button" id="modal-cancel" class="btn ghost">Cancel</button>
           <button type="submit" id="modal-submit" class="btn primary">Add</button>
@@ -548,6 +627,8 @@
         </div>
         <label for="u-history-days">History retention (days, blank = default)</label>
         <input type="number" id="u-history-days" min="0" max="365" step="1" placeholder="7">
+        <label for="u-dns-server">Upstream DNS server (blank = inherit)</label>
+        <input id="u-dns-server" placeholder="e.g. 1.1.1.1">
         <div class="modal-actions">
           <button type="button" id="user-modal-cancel" class="btn ghost">Cancel</button>
           <button type="submit" id="user-modal-submit" class="btn primary">Add</button>
@@ -598,6 +679,6 @@
     </div>
   </div>
 
-  <script src="/assets/app.js?v=32"></script>
+  <script src="/assets/app.js?v=33"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds a domain-level DNS filtering layer on top of the dnsmasq install we already run for DHCP + DNS. Nothing about the nftables accounting/blocking path or the tc speed-shaping path changes; this rides entirely on the DHCP tag mechanism dnsmasq already has, so it's additive rather than a rework.

What's new:
- Block, allow, or redirect a domain (and every subdomain of it), scoped globally, to one user, or to one device
- Four ready-to-use blocklist presets: ads & tracking (StevenBlack/hosts), social media (cyb3rko/social-media-hosts-blocklists), streaming (curated inline list, no single good upstream exists for that category), and gambling. Or paste your own hosts-format or AdBlock Plus list
- Per-user / per-device upstream DNS server override, so a device isn't stuck on whatever resolver the router hands out to everyone
- A DNS tab in the dashboard: rule table with add/delete, preset toggles, an import box, plus dns_server fields on the user/device edit modals
- Blacklist or allow a domain straight from the History tab: every domain row now shows a live status badge (blocked / allowed / redirected / no rule) and one-click "block this device" / "block everyone" / "allow" buttons, backed by POST /api/dns/rules/quick
- New domain_rules + dns_presets tables, a dns_server column on users and devices, and the matching /api/dns/* + /api/{users,devices}/{id}/dns routes

How it works: dnsmasq already owns DHCP + DNS, so this generates two extra files inside its conf-dir. quota-tags.conf binds every known MAC to its own DHCP tag (dhcp-host=<mac>,set:qmdev<id>) — that tag is the entire mechanism that makes a per-device or per-user rule possible, since dnsmasq selects config lines by tag. quota-domains.conf holds the actual tag-restricted address=/server= lines. Both are rewritten and diffed every maintenance tick and immediately after any /api/dns/* edit, and dnsmasq is only restarted when the rendered content actually changed — same signature- gated pattern the nftables blocked set and the tc tree already use. A restart (not a SIGHUP) is required for new address=/server=/dhcp-host= lines to take effect, so a rule change costs every client a brief (~1s) DNS blip.

Fixes from the first review pass (see PR discussion):
- SQLite NULL-uniqueness bug: domain_rules' UNIQUE(scope, scope_id, domain, action) never actually deduplicated global rules, because scope_id is NULL for every one of them and SQLite treats every NULL as distinct from every other NULL. Re-submitting the same global rule silently inserted a duplicate instead of updating the existing row. Added a generated scope_key column (COALESCE(scope_id, 0)) and uniqued on that instead, plus a migration that rebuilds any table created under the old schema and drops the duplicates it let through.
- Missing UI: added the DNS tab described above — this was a hard blocker, the feature was API-only before.
- Preset-enable performance: enabling a large preset (StevenBlack's ads-tracking list is 100k+ domains) did one INSERT + one commit per domain in a Python loop, which froze SQLite for minutes and blocked the event loop for the whole request. Replaced with one executemany() in a single transaction (create_domain_rules_bulk), and moved the parsing/ normalization pass off the event loop via asyncio.to_thread.
- Preset scope-change leak: re-enabling an already-enabled preset at a DIFFERENT scope (e.g. moving it from global to one user) left the old scope's rules orphaned forever, since only the new scope's source tag was ever tracked. enable_dns_preset now diffs against the preset's prior recorded scope and purges those rows first.
- Config-injection hardening: target_ip (redirect rules) and dns_server were free-text fields written directly into generated dnsmasq config with no format validation. Now validated as bare IP addresses at the API layer (pydantic field_validator), plus a second independent check inside the renderer itself (_is_safe_config_token) that rejects anything unsafe even if it somehow reached that layer unvalidated.

Rebased twice onto upstream while this was in review, most recently onto the per-device browsing history feature (dnslog.py) — domain_rules, dns_presets, and the dns_server columns were merged by hand around the new dns_history table and history_days field rather than overwriting either side. The History integration above (status badges + quick-action buttons) exists specifically because that feature landed while this one was still in review, and the two turned out to compose naturally: resolve_domain_status() mirrors dnsmasq's own matching rules exactly (longest-domain-match first, then the same scope/action precedence render_rules renders in) rather than approximating them, so the badge always reflects what the live config would actually do.

Known limitations, documented in Structure_README.md rather than left implicit:
- This is DNS-layer filtering. A client using DNS-over-HTTPS/TLS to an external resolver, or one that hardcodes a destination IP, bypasses it the same way it already bypasses this box's regular DNS.
- Per-device/per-user rules and DNS-server overrides depend on the DHCP tag, which dnsmasq only assigns to a MAC it has actually leased. A static-IP device is invisible to tagging the same way it's already invisible to the existing per-device block enforcement (see CLAUDE.md's LEGACY_DEBT_AND_RISKS). Global-scope rules are unaffected.

28 new tests (parsing, rendering, scope/action precedence, config- injection guards, DB CRUD) plus the full existing suite untouched and passing. Full suite: 367/368 — the one failure is a pre-existing, load-sensitive file-tailer test, confirmed to fail identically on a clean checkout of main with no changes applied.